### PR TITLE
add Tab element and .add_tab()

### DIFF
--- a/docx/oxml/text.py
+++ b/docx/oxml/text.py
@@ -245,6 +245,14 @@ class CT_R(OxmlBaseElement):
         self.append(t)
         return t
 
+    def add_tab(self):
+        """
+        Return a newly added CT_Tab (<w:tab/>) element.
+        """
+        tab = CT_Tab.new()
+        self.append(tab)
+        return tab
+
     def get_or_add_rPr(self):
         """
         Return the rPr child element, newly added if not present.
@@ -810,6 +818,19 @@ class CT_RPr(OxmlBaseElement):
         u = OxmlElement('w:u')
         self.insert(0, u)
         return u
+
+
+class CT_Tab(OxmlBaseElement):
+    """
+    ``<w:tab/>`` element
+    """
+    @classmethod
+    def new(cls):
+        """
+        Return a new ``<w:tab/> element>``
+        """
+        tab = OxmlElement('w:tab')
+        return tab
 
 
 class CT_Text(OxmlBaseElement):

--- a/docx/text.py
+++ b/docx/text.py
@@ -143,6 +143,13 @@ class Run(object):
         t = self._r.add_t(text)
         return Text(t)
 
+    def add_tab(self):
+        """
+        Add a tab element to this run.
+        """
+        tab = self._r.add_tab()
+        return Tab(tab)
+
     @boolproperty
     def all_caps(self):
         """
@@ -365,3 +372,12 @@ class Text(object):
     def __init__(self, t_elm):
         super(Text, self).__init__()
         self._t = t_elm
+
+
+class Tab(object):
+    """
+    Proxy object wrapping ``<w:tab>`` element.
+    """
+    def __init__(self, tab_elem):
+        super(Tab, self).__init__()
+        self._tab = tab_elem


### PR DESCRIPTION
Maybe I missed it, but I could not find a way in the current API to add real tabs (i.e., `<w:tab/>`).  This PR adds the necessary classes and methods, following the current design as appropriate.  This also related to #39 
