### PR TITLE
Get all IDs ignoring prefix

### DIFF
--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -81,7 +81,7 @@ class DocumentPart(XmlPart):
         in id sequence are filled. The id attribute value is unique in the
         document, without regard to the element type it appears on.
         """
-        id_str_lst = self._element.xpath('//@id')
+        id_str_lst = self._element.xpath("//@*[local-name() = 'id']")
         used_ids = [int(id_str) for id_str in id_str_lst if id_str.isdigit()]
         for n in range(1, len(used_ids)+2):
             if n not in used_ids:


### PR DESCRIPTION
Hi,

DocumentPart.next_id returns the next available id value for the given document part, but it searches only for 'id' attributes without prefixes. What do you think about this change which takes into account ALL id attributes regardless of prefix?

A bit of background: I'm currently experimenting with adding hyperlinks support to python-docx which requires generating unique id attributes called 'w:id' for 'bookmarkStart' and 'bookmartEnd' tags. I believe the attached fix could help to reuse DocumentPart.next_id for this purpose.

