### PR TITLE
Added new add_list method to enhance lists support.

### DIFF
--- a/docx/api.py
+++ b/docx/api.py
@@ -73,8 +73,9 @@ class Document(object):
 
     def add_list(self, style='ListParagraph', level=0):
         """
-        Return a list paragraph newly added to the end of the document, having
-        paragraph style *style* and indentation level *level*.
+        Return a helper that implements methods to create a list formed by
+        paragraphs sharing the same numId, added to the end of the document,
+        having paragraph style *style* and indentation level *level*.
         """
         return self._document_part.add_list(style=style, level=level)
 

--- a/docx/api.py
+++ b/docx/api.py
@@ -71,6 +71,13 @@ class Document(object):
         """
         return self._document_part.add_paragraph(text, style)
 
+    def add_list(self, style='ListParagraph', level=0):
+        """
+        Return a list paragraph newly added to the end of the document, having
+        paragraph style *style* and indentation level *level*.
+        """
+        return self._document_part.add_list(style=style, level=level)
+
     def add_picture(self, image_path_or_stream, width=None, height=None):
         """
         Return a new picture shape added in its own paragraph at the end of
@@ -136,6 +143,16 @@ class Document(object):
         marks such as ``<w:ins>`` or ``<w:del>`` do not appear in this list.
         """
         return self._document_part.paragraphs
+
+    @property
+    def lists(self):
+        """
+        A list of |ListParagraph| instances corresponding to the paragraphs
+        grouped in lists, in document order. Note that paragraphs within
+        revision marks such as ``<w:ins>`` or ``<w:del>`` do not appear in this
+        list.
+        """
+        return self._document_part.lists
 
     def save(self, path_or_stream):
         """

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -91,8 +91,9 @@ class BlockItemContainer(Parented):
         A list containing the paragraphs grouped in lists in this container,
         in document order. Read-only.
         """
-        nums = [paragraph.numId for paragraph in self.paragraphs]
-        return [ListParagraph(self, numId) for numId in set(filter(bool, nums))]
+        nums = [paragraph.numId for paragraph in self.paragraphs
+                if paragraph.numId is not None]
+        return [ListParagraph(self, numId) for numId in set(nums)]
 
     @property
     def tables(self):

--- a/docx/list.py
+++ b/docx/list.py
@@ -1,0 +1,55 @@
+# encoding: utf-8
+
+"""
+The |ListParagraph| object and related proxy classes.
+"""
+
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+import random
+from .text import Paragraph
+
+
+class ListParagraph(object):
+    """
+    Proxy object for controlling a set of ``<w:p>`` grouped together in a list.
+    """
+    def __init__(self, parent, numId=0, style=None, level=0):
+        self._parent = parent
+        self.numId = numId
+        self.level = level
+        self.style = style
+
+    def add_item(self, text=None, style=None):
+        """
+        Add a paragraph item to the current list, having text set to *text* and
+        a paragraph style *style*
+        """
+        item = self._parent.add_paragraph(text, style=style)
+        item.level = self.level
+        item.numId = self.numId
+        return item
+
+    def add_list(self, style=None):
+        """
+        Add a list indented one level below the current one, having a paragraph
+        style *style*. Note that the document will only be altered once the
+        first item has been added to the list.
+        """
+        return ListParagraph(
+            self._parent,
+            numId=self._parent.generate_numId(),
+            style=style if style is not None else self.style,
+            level=self.level+1,
+        )
+
+    @property
+    def items(self):
+        """
+        Sequence of |Paragraph| instances corresponding to the item elements
+        in this list paragraph.
+        """
+        return [paragraph for paragraph in self._parent.paragraphs
+                if paragraph.numId == self.numId]

--- a/docx/oxml/text.py
+++ b/docx/oxml/text.py
@@ -24,7 +24,7 @@ class CT_Br(BaseOxmlElement):
 
 class CT_Jc(BaseOxmlElement):
     """
-    ``<w:jc>`` element, specifying paragraph justification.
+    ``<w:ivl>`` element, specifying paragraph justification.
     """
     val = RequiredAttribute('w:val', WD_ALIGN_PARAGRAPH)
 
@@ -165,6 +165,13 @@ class CT_PPr(BaseOxmlElement):
         pStyle = self.get_or_add_pStyle()
         pStyle.val = style
 
+
+class CT_NumPr(BaseOxmlElement):
+    """
+    ``<w:numPr>`` element, containing properties useful for lists.
+    """
+    numId = ZeroOrOne('w:numId')
+    ilvl = ZeroOrOne('w:ilvl')
 
 class CT_R(BaseOxmlElement):
     """

--- a/docx/oxml/text.py
+++ b/docx/oxml/text.py
@@ -24,7 +24,7 @@ class CT_Br(BaseOxmlElement):
 
 class CT_Jc(BaseOxmlElement):
     """
-    ``<w:ivl>`` element, specifying paragraph justification.
+    ``<w:jc>`` element, specifying paragraph justification.
     """
     val = RequiredAttribute('w:val', WD_ALIGN_PARAGRAPH)
 

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -45,6 +45,13 @@ class DocumentPart(XmlPart):
         """
         return self.body.add_table(rows, cols)
 
+    def add_list(self, style=None, level=0):
+        """
+        Return a paragraph newly added to the end of the body content and
+        formatted to contain a list.
+        """
+        return self.body.add_list(style=style, level=level)
+
     @lazyproperty
     def body(self):
         """
@@ -94,6 +101,16 @@ class DocumentPart(XmlPart):
         marks such as inserted or deleted do not appear in this list.
         """
         return self.body.paragraphs
+
+    @property
+    def lists(self):
+        """
+        A list of |ListParagraph| instances corresponding to the paragraphs in
+        parts of lists in the document, in document order.
+        Note that list paragraphs within revision marks such as inserted or
+        deleted do not appear in this list.
+        """
+        return self.body.lists
 
     @lazyproperty
     def sections(self):

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -47,8 +47,10 @@ class DocumentPart(XmlPart):
 
     def add_list(self, style=None, level=0):
         """
-        Return a paragraph newly added to the end of the body content and
-        formatted to contain a list.
+        Return a helper that provides methods to add paragraphs to the end of
+        the body content, grouped together as a list. The paragraphs will by
+        default have their paragraph style set to *style*, and their indentation
+        level set to *level*.
         """
         return self.body.add_list(style=style, level=level)
 
@@ -105,8 +107,8 @@ class DocumentPart(XmlPart):
     @property
     def lists(self):
         """
-        A list of |ListParagraph| instances corresponding to the paragraphs in
-        parts of lists in the document, in document order.
+        A list of |ListParagraph| instances corresponding to lists formed by
+        paragraphs sharing the same numId in the document, in document order.
         Note that list paragraphs within revision marks such as inserted or
         deleted do not appear in this list.
         """

--- a/docx/text.py
+++ b/docx/text.py
@@ -63,13 +63,6 @@ class Paragraph(Parented):
         super(Paragraph, self).__init__(parent)
         self._p = p
 
-        # XPath: w:p/w:pPr/w:numPr
-        numPr = p.get_or_add_pPr().get_or_add_numPr()
-        # XPath: w:p/w:pPr/w:numPr/w:ilvl
-        self._ilvl = numPr.get_or_add_ilvl()
-        # XPath: w:p/w:pPr/w:numPr/w:numId
-        self._numId = numPr.get_or_add_numId()
-
     def add_run(self, text=None, style=None):
         """
         Append a run to this paragraph containing *text* and having character
@@ -92,28 +85,40 @@ class Paragraph(Parented):
         """
         Return the numId of the parent list.
         """
-        return self._numId.val
+        if self._p.pPr is None:
+            return None
+        if self._p.pPr.numPr is None:
+            return None
+        if self._p.pPr.numPr.numId is None:
+            return None
+        return self._p.pPr.numPr.numId.val
 
     @numId.setter
     def numId(self, numId):
         """
         Set the numId of the parent list.
         """
-        self._numId.val = numId
+        self._p.get_or_add_pPr().get_or_add_numPr().get_or_add_numId().val = numId
 
     @property
     def level(self):
         """
         Return the indentation level of the parent list.
         """
-        return self._ilvl.val
+        if self._p.pPr is None:
+            return None
+        if self._p.pPr.numPr is None:
+            return None
+        if self._p.pPr.numPr.ilvl is None:
+            return None
+        return self._p.pPr.numPr.ilvl.val
 
     @level.setter
     def level(self, lvl):
         """
         Set the indentation level of the parent list.
         """
-        self._ilvl.val = lvl
+        self._p.get_or_add_pPr().get_or_add_numPr().get_or_add_ilvl().val = lvl
 
     @property
     def alignment(self):

--- a/docx/text.py
+++ b/docx/text.py
@@ -63,6 +63,13 @@ class Paragraph(Parented):
         super(Paragraph, self).__init__(parent)
         self._p = p
 
+        # XPath: w:p/w:pPr/w:numPr
+        numPr = p.get_or_add_pPr().get_or_add_numPr()
+        # XPath: w:p/w:pPr/w:numPr/w:ilvl
+        self._ilvl = numPr.get_or_add_ilvl()
+        # XPath: w:p/w:pPr/w:numPr/w:numId
+        self._numId = numPr.get_or_add_numId()
+
     def add_run(self, text=None, style=None):
         """
         Append a run to this paragraph containing *text* and having character
@@ -79,6 +86,34 @@ class Paragraph(Parented):
         if style:
             run.style = style
         return run
+
+    @property
+    def numId(self):
+        """
+        Return the numId of the parent list.
+        """
+        return self._numId.val
+
+    @numId.setter
+    def numId(self, numId):
+        """
+        Set the numId of the parent list.
+        """
+        self._numId.val = numId
+
+    @property
+    def level(self):
+        """
+        Return the indentation level of the parent list.
+        """
+        return self._ilvl.val
+
+    @level.setter
+    def level(self, lvl):
+        """
+        Set the indentation level of the parent list.
+        """
+        self._ilvl.val = lvl
 
     @property
     def alignment(self):


### PR DESCRIPTION
Added support for multiple numbered/bullet lists with a new **add_list** api method. 

Fixes issue #25.
- **BlockItemContainer** has been improved with a new method to generate unique _numId_ values
- Created a new **ListParagraph** proxy that supports adding Paragraph instances sharing the same _numId_ values.
- **Paragraph** has a couple of new getters/setters to access _numId_ and _ilvl_

TODO:
- [ ] Tests 
- [ ] documentation

Example:

``` python
    document = Document()
    a_list = document.add_list(style='ListParagraph')
    # add_item() behaves exactly like Document.add_paragraph()
    a_list.add_item('first')
    a_list.add_item().add_run('second').bold = True

    # You can even create sub-lists to increase the indentation of sub-items
    b_list = a_list.add_list()
    b_list.add_item('one')
    b_list.add_item('two')

    # List of lists in the document
    print(len(document.lists))
```
