### PR TITLE
adds support for reading/writing Run text color

### DIFF
--- a/docx/oxml/text.py
+++ b/docx/oxml/text.py
@@ -208,6 +208,38 @@ class CT_R(BaseOxmlElement):
             self.remove(child)
 
     @property
+    def color(self):
+        """
+        String contained in w:val attribute of <w:color> grandchild, or
+        |None| if that element is not present.
+        """
+        rPr = self.rPr
+        if rPr is None:
+            return None
+
+        if rPr.color is None:
+            return None
+
+        try:
+            return rPr.color.values()[0]
+        except (AttributeError, IndexError):
+            return None
+
+    @color.setter
+    def color(self, color):
+        """
+        Set the w:color value of this <w:r> element to *color*. If *color*
+        is None, remove the color element.
+        """
+        rPr = self.get_or_add_rPr()
+
+        if color is None:
+            rPr._remove_color()
+        else:
+            rPr.color.clear()
+            rPr.color.set(qn('w:val'), color)
+
+    @property
     def style(self):
         """
         String contained in w:val attribute of <w:rStyle> grandchild, or
@@ -275,6 +307,7 @@ class CT_RPr(BaseOxmlElement):
     b = ZeroOrOne('w:b', successors=('w:rPrChange',))
     bCs = ZeroOrOne('w:bCs', successors=('w:rPrChange',))
     caps = ZeroOrOne('w:caps', successors=('w:rPrChange',))
+    color = ZeroOrOne('w:color', successors=('w:rPrChange',))
     cs = ZeroOrOne('w:cs', successors=('w:rPrChange',))
     dstrike = ZeroOrOne('w:dstrike', successors=('w:rPrChange',))
     emboss = ZeroOrOne('w:emboss', successors=('w:rPrChange',))

--- a/docx/text.py
+++ b/docx/text.py
@@ -266,6 +266,21 @@ class Run(Parented):
         self._r.clear_content()
         return self
 
+    @property
+    def color(self):
+        """
+        Read/write. The string hex color applied to
+        this run, or |None| if it has no directly-applied character color.
+        Setting this property to |None| causes any directly-applied character
+        color to be removed such that the run inherits character formatting
+        from its containing paragraph.
+        """
+        return self._r.color
+
+    @color.setter
+    def color(self, hex_value):
+        self._r.color = hex_value
+
     @boolproperty
     def complex_script(self):
         """


### PR DESCRIPTION
The patch adds a 'color' attribute to a Run so that you can change the foreground text color.