### PR TITLE
Ensure DPI key exists in image info before accessing.

### DIFF
--- a/docx/image/tiff.py
+++ b/docx/image/tiff.py
@@ -118,6 +118,10 @@ class _TiffParser(object):
         """
         if resolution_tag not in self._ifd_entries:
             return 72
+
+        if TIFF_TAG.RESOLUTION_UNIT not in self._ifd_entries:
+            return 72
+
         resolution_unit = self._ifd_entries[TIFF_TAG.RESOLUTION_UNIT]
         if resolution_unit == 1:  # aspect ratio only
             return 72


### PR DESCRIPTION
I was having trouble producing word documents that included images taken with an iPad running iOS 8.1.2.  I realized it's because this release of iOS does not include the 'Resolution Unit' key in the TIFF info of it's photos.  Adding this simple check fixes it by assuming a safe value for the DPI when it not given in the image info...