### PR TITLE
Assume inches if resolution unit not given in image TIFF metadata.

### DIFF
--- a/docx/image/tiff.py
+++ b/docx/image/tiff.py
@@ -119,9 +119,6 @@ class _TiffParser(object):
         if resolution_tag not in self._ifd_entries:
             return 72
 
-        if TIFF_TAG.RESOLUTION_UNIT not in self._ifd_entries:
-            return 72
-
         # get resolution unit, assume inches if not specified
         if TIFF_TAG.RESOLUTION_UNIT not in self._ifd_entries:
             resolution_unit = 2

--- a/docx/image/tiff.py
+++ b/docx/image/tiff.py
@@ -118,7 +118,16 @@ class _TiffParser(object):
         """
         if resolution_tag not in self._ifd_entries:
             return 72
-        resolution_unit = self._ifd_entries[TIFF_TAG.RESOLUTION_UNIT]
+
+        if TIFF_TAG.RESOLUTION_UNIT not in self._ifd_entries:
+            return 72
+
+        # get resolution unit, assume inches if not specified
+        if TIFF_TAG.RESOLUTION_UNIT not in self._ifd_entries:
+            resolution_unit = 2
+        else:
+            resolution_unit = self._ifd_entries[TIFF_TAG.RESOLUTION_UNIT]
+
         if resolution_unit == 1:  # aspect ratio only
             return 72
         # resolution_unit == 2 for inches, 3 for centimeters


### PR DESCRIPTION
Cannot assume that the resolution unit is given if the x and y resolution values are given.  Inches is probably the safest assumption.