### PR TITLE
Updated documentation for _ in Word style names.

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -163,7 +163,7 @@ gallery. You can apply one of those to the table like this::
 
     table.style = 'LightShading-Accent1'
 
-The style name is formed by removing all the spaces from the table style name.
+The style name is formed by removing all the spaces (also underscores '_') from the table style name.
 You can find the table style name by hovering your mouse over its thumbnail in
 Word's table style gallery.
 


### PR DESCRIPTION
I spent quite some time trying to debug this. Documentation mentions spaces, but even _ are replaced.