### PR TITLE
Avoid triggering the "style lookup by style_id is deprecated" warning ourselves.

### DIFF
--- a/docx/api.py
+++ b/docx/api.py
@@ -40,8 +40,8 @@ class Document(object):
         Return a heading paragraph newly added to the end of the document,
         populated with *text* and having the heading paragraph style
         determined by *level*. If *level* is 0, the style is set to
-        ``'Title'``. If *level* is 1 (or not present), ``'Heading1'`` is used.
-        Otherwise the style is set to ``'Heading{level}'``. If *level* is
+        ``'Title'``. If *level* is 1 (or not present), ``'Heading 1'`` is used.
+        Otherwise the style is set to ``'Heading {level}'``. If *level* is
         outside the range 0-9, |ValueError| is raised.
         """
         if not 0 <= level <= 9:
@@ -100,7 +100,7 @@ class Document(object):
         """
         Add a table having row and column counts of *rows* and *cols*
         respectively and table style of *style*. If *style* is |None|, a
-        table with no style is produced.
+        table with 'Light Shading Accent 1' style is produced.
         """
         table = self._document_part.add_table(rows, cols)
         if style:

--- a/docx/api.py
+++ b/docx/api.py
@@ -46,7 +46,7 @@ class Document(object):
         """
         if not 0 <= level <= 9:
             raise ValueError("level must be in range 0-9, got %d" % level)
-        style = 'Title' if level == 0 else 'Heading%d' % level
+        style = 'Title' if level == 0 else 'Heading %d' % level
         return self.add_paragraph(text, style)
 
     def add_page_break(self):
@@ -96,7 +96,7 @@ class Document(object):
         """
         return self._document_part.add_section(start_type)
 
-    def add_table(self, rows, cols, style='LightShading-Accent1'):
+    def add_table(self, rows, cols, style='Light Shading Accent 1'):
         """
         Add a table having row and column counts of *rows* and *cols*
         respectively and table style of *style*. If *style* is |None|, a

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -165,8 +165,8 @@ class DescribeDocument(object):
 
     @pytest.fixture(params=[
         ('',         None),
-        ('',         'Heading1'),
-        ('foo\rbar', 'BodyText'),
+        ('',         'Heading 1'),
+        ('foo\rbar', 'Body Text'),
     ])
     def add_paragraph_fixture(
             self, request, document, document_part_, paragraph_):
@@ -178,7 +178,7 @@ class DescribeDocument(object):
             self, request, document, add_paragraph_, paragraph_):
         level = request.param
         text = 'Spam vs. Bacon'
-        style = 'Title' if level == 0 else 'Heading%d' % level
+        style = 'Title' if level == 0 else 'Heading %d' % level
         return document, add_paragraph_, paragraph_, text, level, style
 
     @pytest.fixture
@@ -199,7 +199,7 @@ class DescribeDocument(object):
     def add_section_fixture(self, document, start_type_, section_):
         return document, start_type_, section_
 
-    @pytest.fixture(params=[None, 'LightShading-Accent1', 'foobar'])
+    @pytest.fixture(params=[None, 'Light Shading Accent 1', 'foobar'])
     def add_table_fixture(self, request, document, document_part_, table_):
         rows, cols = 4, 2
         style = expected_style = request.param


### PR DESCRIPTION
The API has changed to use style names rather than style IDs.  This is a great step forward, but it now generates "style lookup by style_id is deprecated" warnings if headings (with a level number) or tables (without a style) are added to the document.  This pull request fixes the automatic style name generation for headings and uses a valid style name for new tables.