### PR TITLE
add feature: Paragraph.add_hyperlink() #74

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,6 +151,8 @@ rst_epilog = """
 
 .. |Run| replace:: :class:`.Run`
 
+.. |Hyperlink| replace:: :class:`Hyperlink`
+
 .. |Section| replace:: :class:`.Section`
 
 .. |Sections| replace:: :class:`.Sections`

--- a/docs/dev/analysis/features/text/hyperlink.rst
+++ b/docs/dev/analysis/features/text/hyperlink.rst
@@ -1,0 +1,164 @@
+
+Hyperlink
+=========
+
+Word allows hyperlinks to be placed in the document or existing objects to be
+turned into hyperlinks.
+
+Hyperlinks can point to a named object or range within the current document or
+to an external resource. Hyperlinks can contain multiple runs of text.
+
+
+Candidate protocol
+------------------
+
+Add a simple hyperlink with text and url:
+
+    >>> hyperlink = paragraph.add_hyperlink(text='Google', url='http://google.com')
+    >>> hyperlink.text
+    'Google'
+    >>> hyperlink.url
+    'http://google.com'
+    >>> hyperlink.anchor
+    None
+    >>> len(hyperlink.runs)
+    1
+
+Add multiple runs to a hyperlink:
+
+    >>> hyperlink = paragraph.add_hyperlink(url='http://github.com')
+    >>> hyperlink.add_run('A')
+    >>> hyperlink.add_run('formatted').italic = True
+    >>> hyperlink.add_run('link').bold = True
+    >>> len(hyperlink.runs)
+    3
+
+Add a hyperlink pointing to a named range in the current document:
+
+    >>> hyperlink = paragraph.add_hyperlink(text='Section 1', anchor='section1')
+    >>> hyperlink.anchor
+    'section1'
+    >>> hyperlink.url
+    None
+
+Turning an existing object into a hyperlink:
+
+    >>> existing_object = document.add_paragraph('Some text')
+    >>> hyperlink = existing_object.hyperlink(url='http://google.com')
+    >>> hyperlink.text
+    'Some text'
+    >>> len(hyperlink.runs)
+    1
+
+
+Specimen XML
+------------
+
+.. highlight:: xml
+
+A simple hyperlink to an external url::
+
+  <w:hyperlink r:id="rId9">
+    <w:r>
+      <w:rPr>
+        <w:rStyle w:val="Hyperlink"/>
+      </w:rPr>
+      <w:t>Google</w:t>
+    </w:r>
+  </w:hyperlink>
+
+
+The relationship for the above url::
+
+    <Relationships xmlns="…">
+      <Relationship Id="rId9" Mode="External" Target=http://google.com />
+    </Relationships>
+
+A hyperlink to an internal named range::
+
+    <w:hyperlink r:anchor="section1">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+        </w:rPr>
+        <w:t>Google</w:t>
+      </w:r>
+    </w:hyperlink>
+
+A hyperlink with multiple runs of text::
+
+    <w:hyperlink r:id="rId2">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+        </w:rPr>
+        <w:t>A</w:t>
+      </w:r>
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+          <w:i/>
+        </w:rPr>
+        <w:t xml:space="preserve">formatted</w:t>
+      </w:r>
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+          <w:b/>
+        </w:rPr>
+        <w:t xml:space="preserve">link</w:t>
+      </w:r>
+    </w:hyperlink>
+
+
+Resources
+---------
+
+* `Document Members (Word) on MSDN`_
+* `Hyperlink Members (Word) on MSDN`_
+* `Hyperlinks Members (Word) on MSDN`_
+* `Hyperlink Class (OpenXML.Office2010.CustomUI) on MSDN`_
+* `Hyperlink Class (OpenXML.Wordprocessing) on MSDN`_
+
+
+.. _Document Members (Word) on MSDN:
+   http://msdn.microsoft.com/en-us/library/office/ff840898.aspx
+
+.. _Hyperlink Members (Word) on MSDN:
+   http://msdn.microsoft.com/en-us/library/office/ff195109.aspx
+
+.. _Hyperlinks Members (Word) on MSDN:
+   http://msdn.microsoft.com/en-us/library/office/ff192421.aspx
+
+.. _Hyperlink Class (OpenXML.Office2010.CustomUI) on MSDN:
+   http://msdn.microsoft.com/en-us/library/documentformat.openxml.office2010.customui.hyperlink.aspx
+
+.. _Hyperlink Class (OpenXML.Wordprocessing) on MSDN:
+   http://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.hyperlink.aspx
+
+
+MS API
+------
+
+The Hyperlinks property on Document holds references to hyperlink
+objects in the MS API.
+
+Hyperlinks contain the following properties:
+
+* Address
+* SubAddress
+* EmailSubject
+* ExtraInfoRequired
+* Range (In python-docx this would be the runs inside the hyperlink)
+* ScreenTip
+* Shape
+* Target (where to open the hyperlink. e.g. "_blank", "_left", "_top", "_self", "_parent" etc)
+* TextToDisplay
+* Type (msoHyperlinkRange, msoHyperlinkShape or msoHyperlinkInlineShape)
+
+
+Spec references
+---------------
+
+* 17.16.17 hyperlink (Hyperlink)
+* 2.3.61 CT_Hyperlink

--- a/docs/dev/analysis/features/text/hyperlink.rst
+++ b/docs/dev/analysis/features/text/hyperlink.rst
@@ -2,53 +2,51 @@
 Hyperlink
 =========
 
-Word allows hyperlinks to be placed in the document or existing objects to be
-turned into hyperlinks.
+Word allows hyperlinks to be placed in the document.
 
-Hyperlinks can point to a named object or range within the current document or
-to an external resource. Hyperlinks can contain multiple runs of text.
+Hyperlink may link to a external location, for example, as an url. It may link to
+a location within the document, for example, as a bookmark. These two cases are
+handled differently.
 
+Hyperlinks can contain multiple runs of text.
 
 Candidate protocol
 ------------------
 
+The hyperlink feature supports only external links today (03/2016).
+
 Add a simple hyperlink with text and url:
 
-    >>> hyperlink = paragraph.add_hyperlink(text='Google', url='http://google.com')
+    >>> hyperlink = paragraph.add_hyperlink(text='Google', address='https://google.com')
+    >>> hyperlink
+    <docx.text.hyperlink.Hyperlink at 0x7f...>
     >>> hyperlink.text
     'Google'
-    >>> hyperlink.url
-    'http://google.com'
-    >>> hyperlink.anchor
-    None
-    >>> len(hyperlink.runs)
-    1
+    >>> hyperlink.address
+    'https://google.com'
+    >>> hyperlink.runs
+    [<docx.text.run.Run at 0x7f...>]
 
 Add multiple runs to a hyperlink:
 
-    >>> hyperlink = paragraph.add_hyperlink(url='http://github.com')
+    >>> hyperlink = paragraph.add_hyperlink(address='https://github.com')
     >>> hyperlink.add_run('A')
     >>> hyperlink.add_run('formatted').italic = True
     >>> hyperlink.add_run('link').bold = True
-    >>> len(hyperlink.runs)
-    3
+    >>> hyperlink.runs
+    [<docx.text.run.Run at 0x7f...>,
+    <docx.text.run.Run at 0x7fb...>,
+    <docx.text.run.Run at 0x7fb...>]
 
-Add a hyperlink pointing to a named range in the current document:
+Retrieve a paragraph's content:
 
-    >>> hyperlink = paragraph.add_hyperlink(text='Section 1', anchor='section1')
-    >>> hyperlink.anchor
-    'section1'
-    >>> hyperlink.url
-    None
+    >>> paragraph = document.add_paragraph('A plain paragraph having some ')
+    >>> paragraph.add_run('link such as ')
+    >>> paragraph.add_hyperlink(address='http://github.com', text='github')
+    >>> paragraph.iter_p_content():
+    [<docx.text.paragraph.Run at 0x7f...>,
+    <docx.text.paragraph.Hyperlink at 0x7f...>]
 
-Turning an existing object into a hyperlink:
-
-    >>> existing_object = document.add_paragraph('Some text')
-    >>> hyperlink = existing_object.hyperlink(url='http://google.com')
-    >>> hyperlink.text
-    'Some text'
-    >>> len(hyperlink.runs)
-    1
 
 
 Specimen XML
@@ -56,109 +54,159 @@ Specimen XML
 
 .. highlight:: xml
 
+
+External links
+~~~~~~~~~~~~~~
+
+An external link is specified by the attribute r:id. The location of the link
+is defined in the relationships part of the document.
+
 A simple hyperlink to an external url::
 
-  <w:hyperlink r:id="rId9">
-    <w:r>
-      <w:rPr>
-        <w:rStyle w:val="Hyperlink"/>
-      </w:rPr>
-      <w:t>Google</w:t>
-    </w:r>
-  </w:hyperlink>
-
-
-The relationship for the above url::
-
-    <Relationships xmlns="…">
-      <Relationship Id="rId9" Mode="External" Target=http://google.com />
-    </Relationships>
-
-A hyperlink to an internal named range::
-
-    <w:hyperlink r:anchor="section1">
+    <w:p>
       <w:r>
-        <w:rPr>
-          <w:rStyle w:val="Hyperlink"/>
-        </w:rPr>
-        <w:t>Google</w:t>
+        <w:t xml:space="preserve">This is an external link to </w:t>
       </w:r>
-    </w:hyperlink>
+      <w:hyperlink r:id="rId4">
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t>Google</w:t>
+        </w:r>
+      </w:hyperlink>
+    </w:p>
+
+
+The r:id="rId4" references the following relationship within the relationships
+part for the document document.xml.rels.::
+
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId4" Mode="External"
+      Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+      Target="http://google.com/"/>
+    </Relationships>
 
 A hyperlink with multiple runs of text::
 
-    <w:hyperlink r:id="rId2">
+    <w:p>
+      <w:hyperlink r:id="rId2">
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t>A</w:t>
+        </w:r>
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+            <w:i/>
+          </w:rPr>
+          <w:t xml:space="preserve"> formatted</w:t>
+        </w:r>
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+            <w:b/>
+          </w:rPr>
+          <w:t xml:space="preserve"> link</w:t>
+        </w:r>
+      </w:hyperlink>
+    </w:p>
+
+
+Internal links
+~~~~~~~~~~~~~~
+
+An internal link, that link to a location in the document, do not have the r:id attribute
+and is specified by the anchor attribute.
+The value of the anchor attribute is the name of a bookmark in the document.
+
+Example::
+
+    <w:p>
       <w:r>
-        <w:rPr>
-          <w:rStyle w:val="Hyperlink"/>
-        </w:rPr>
-        <w:t>A</w:t>
+        <w:t xml:space="preserve">This is an </w:t>
       </w:r>
+      <w:hyperlink w:anchor="myAnchor">
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t>internal link</w:t>
+        </w:r>
+      </w:hyperlink>
+    </w:p>
+
+    ...
+
+    <w:p>
       <w:r>
-        <w:rPr>
-          <w:rStyle w:val="Hyperlink"/>
-          <w:i/>
-        </w:rPr>
-        <w:t xml:space="preserve">formatted</w:t>
+        <w:t xml:space="preserve">This is text with a </w:t>
       </w:r>
-      <w:r>
-        <w:rPr>
-          <w:rStyle w:val="Hyperlink"/>
-          <w:b/>
-        </w:rPr>
-        <w:t xml:space="preserve">link</w:t>
-      </w:r>
-    </w:hyperlink>
+      <w:bookmarkStart w:id="0" w:name="myAnchor"/>
+        <w:r>
+          <w:t>bookmark</w:t>
+        </w:r>
+      <w:bookmarkEnd w:id="0"/>
+    </w:p>
 
 
-Resources
----------
+Schema excerpt
+--------------
 
-* `Document Members (Word) on MSDN`_
-* `Hyperlink Members (Word) on MSDN`_
-* `Hyperlinks Members (Word) on MSDN`_
-* `Hyperlink Class (OpenXML.Office2010.CustomUI) on MSDN`_
-* `Hyperlink Class (OpenXML.Wordprocessing) on MSDN`_
+.. highlight:: xml
 
+::
 
-.. _Document Members (Word) on MSDN:
-   http://msdn.microsoft.com/en-us/library/office/ff840898.aspx
+    <xsd:complexType name="CT_P">
+      <xsd:sequence>
+        <xsd:element name="pPr" type="CT_PPr" minOccurs="0"/>
+        <xsd:group   ref="EG_PContent"        minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="rsidRPr"      type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidR"        type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidDel"      type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidP"        type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidRDefault" type="ST_LongHexNumber"/>
+    </xsd:complexType>
 
-.. _Hyperlink Members (Word) on MSDN:
-   http://msdn.microsoft.com/en-us/library/office/ff195109.aspx
+    <xsd:complexType name="CT_Hyperlink">
+      <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="tgtFrame" type="s:ST_String" use="optional"/>
+      <xsd:attribute name="tooltip" type="s:ST_String" use="optional"/>
+      <xsd:attribute name="docLocation" type="s:ST_String" use="optional"/>
+      <xsd:attribute name="history" type="s:ST_OnOff" use="optional"/>
+      <xsd:attribute name="anchor" type="s:ST_String" use="optional"/>
+      <xsd:attribute ref="r:id"/>
+    </xsd:complexType>
 
-.. _Hyperlinks Members (Word) on MSDN:
-   http://msdn.microsoft.com/en-us/library/office/ff192421.aspx
+    <xsd:group name="EG_PContent">  <!-- denormalized -->
+      <xsd:choice>
+        <xsd:element name="r"               type="CT_R"/>
+        <xsd:element name="hyperlink"       type="CT_Hyperlink"/>
+        <xsd:element name="fldSimple"       type="CT_SimpleField"/>
+        <xsd:element name="sdt"             type="CT_SdtRun"/>
+        <xsd:element name="customXml"       type="CT_CustomXmlRun"/>
+        <xsd:element name="smartTag"        type="CT_SmartTagRun"/>
+        <xsd:element name="dir"             type="CT_DirContentRun"/>
+        <xsd:element name="bdo"             type="CT_BdoContentRun"/>
+        <xsd:element name="subDoc"          type="CT_Rel"/>
+        <xsd:group    ref="EG_RunLevelElts"/>
+      </xsd:choice>
+    </xsd:group>
 
-.. _Hyperlink Class (OpenXML.Office2010.CustomUI) on MSDN:
-   http://msdn.microsoft.com/en-us/library/documentformat.openxml.office2010.customui.hyperlink.aspx
+    <xsd:complexType name="CT_R">
+      <xsd:sequence>
+        <xsd:group ref="EG_RPr"             minOccurs="0"/>
+        <xsd:group ref="EG_RunInnerContent" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="rsidRPr" type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidDel" type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidR"   type="ST_LongHexNumber"/>
+    </xsd:complexType>
 
-.. _Hyperlink Class (OpenXML.Wordprocessing) on MSDN:
-   http://msdn.microsoft.com/en-us/library/documentformat.openxml.wordprocessing.hyperlink.aspx
+    <xsd:simpleType name="ST_RelationshipId">
+      <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
 
-
-MS API
-------
-
-The Hyperlinks property on Document holds references to hyperlink
-objects in the MS API.
-
-Hyperlinks contain the following properties:
-
-* Address
-* SubAddress
-* EmailSubject
-* ExtraInfoRequired
-* Range (In python-docx this would be the runs inside the hyperlink)
-* ScreenTip
-* Shape
-* Target (where to open the hyperlink. e.g. "_blank", "_left", "_top", "_self", "_parent" etc)
-* TextToDisplay
-* Type (msoHyperlinkRange, msoHyperlinkShape or msoHyperlinkInlineShape)
-
-
-Spec references
----------------
-
-* 17.16.17 hyperlink (Hyperlink)
-* 2.3.61 CT_Hyperlink

--- a/docs/dev/analysis/features/text/index.rst
+++ b/docs/dev/analysis/features/text/index.rst
@@ -10,4 +10,5 @@ Text
    font-color
    underline
    run-content
+   hyperlink
    breaks

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -180,6 +180,9 @@ register_element_cls('w:webHidden',  CT_OnOff)
 from .text.paragraph import CT_P
 register_element_cls('w:p', CT_P)
 
+from .text.hyperlink import CT_Hyperlink
+register_element_cls('w:hyperlink', CT_Hyperlink)
+
 from .text.parfmt import CT_Ind, CT_Jc, CT_PPr, CT_Spacing
 register_element_cls('w:ind',             CT_Ind)
 register_element_cls('w:jc',              CT_Jc)

--- a/docx/oxml/text/hyperlink.py
+++ b/docx/oxml/text/hyperlink.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+
+"""
+Custom element classes related to hyperlinks (CT_Hyperlink).
+"""
+
+from ..ns import qn
+from ..simpletypes import ST_RelationshipId
+from ..xmlchemy import (
+    BaseOxmlElement, RequiredAttribute, ZeroOrMore
+)
+
+
+class CT_Hyperlink(BaseOxmlElement):
+    """
+    ``<w:hyperlink>`` element, containing the properties and text for a hyperlink.
+
+    The ``<w:hyperlink>`` contains a ``<w:r>`` element which holds all the
+    visible content. The ``<w:hyperlink>`` has an attribute ``r:id`` which
+    holds an ID relating a URL in the document's relationships.
+    """
+    r = ZeroOrMore('w:r')
+    rid = RequiredAttribute('r:id', ST_RelationshipId)
+
+    @property
+    def relationship(self):
+        """
+        String contained in ``r:id`` attribute of <w:hyperlink>. It should
+        point to a URL in the document's relationships.
+        """
+        val = self.get(qn('r:id'))
+        return val
+
+    @relationship.setter
+    def relationship(self, rId):
+        self.set(qn('r:id'), rId)
+        self.set(qn('w:history'), '1')
+
+    def clear_content(self):
+        """
+        Remove all child r elements
+        """
+        r_to_rm = []
+        for child in self[:]:
+            if child.tag == qn('w:r'):
+                r_to_rm.append(child)
+        for r in r_to_rm:
+            self.remove(r)

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -14,6 +14,7 @@ class CT_P(BaseOxmlElement):
     """
     pPr = ZeroOrOne('w:pPr')
     r = ZeroOrMore('w:r')
+    hyperlink = ZeroOrMore('w:hyperlink')
 
     def _insert_pPr(self, pPr):
         self.insert(0, pPr)

--- a/docx/text/hyperlink.py
+++ b/docx/text/hyperlink.py
@@ -1,0 +1,88 @@
+# encoding: utf-8
+
+"""
+Hyperlink proxy objects.
+"""
+
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+from .run import Run
+from ..shared import Parented
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+
+
+class Hyperlink(Parented):
+    """
+    Proxy object wrapping ``<w:hyperlink>`` element, which in turn contains a
+    ``<w:r>`` element. It has two main properties: The *url* it points to and
+    the *text* that is shown on the page.
+    """
+    def __init__(self, hyperlink, parent):
+        super(Hyperlink, self).__init__(parent)
+        self._hyperlink = self.element = hyperlink
+
+    @property
+    def url(self):
+        """
+        Read/write. The relationship ID the Hyperlink points to, or |None| if
+        it has no directly-applied relationship. Setting this property sets
+        the The ``r:id`` attribute of the ``<w:rPr>`` element inside the
+        hyperlink.
+        """
+        part = self.part
+        rId = self._hyperlink.relationship
+        url = part.target_ref(rId) if rId else ''
+        return url
+
+    @url.setter
+    def url(self, url):
+        part = self.part
+        rId = part.relate_to(url, RT.HYPERLINK, is_external=True)
+        self._hyperlink.relationship = rId
+
+    @property
+    def runs(self):
+        """
+        Sequence of |Run| instances corresponding to the <w:r> elements in
+        this hyperlink.
+        """
+        return [Run(r, self) for r in self._hyperlink.r_lst]
+
+    def add_run(self, text=None, style=None):
+        """
+        Append a run to this hyperlink containing *text* and having character
+        style identified by style ID *style*. *text* can contain tab
+        (``\\t``) characters, which are converted to the appropriate XML form
+        for a tab. *text* can also include newline (``\\n``) or carriage
+        return (``\\r``) characters, each of which is converted to a line
+        break.
+        """
+        r = self._hyperlink.add_r()
+        run = Run(r, self)
+        if text:
+            run.text = text
+        if style:
+            run.style = style
+        return run
+
+    @property
+    def text(self):
+        text = ''
+        for run in self.runs:
+            text += run.text
+        return text
+
+    @text.setter
+    def text(self, text):
+        self._hyperlink.clear_content()
+        self.add_run(text)
+
+
+class Text(object):
+    """
+    Proxy object wrapping ``<w:t>`` element.
+    """
+    def __init__(self, t_elm):
+        super(Text, self).__init__()
+        self._t = t_elm

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -11,6 +11,7 @@ from __future__ import (
 from ..enum.style import WD_STYLE_TYPE
 from .parfmt import ParagraphFormat
 from .run import Run
+from .hyperlink import Hyperlink
 from ..shared import Parented
 
 
@@ -38,6 +39,31 @@ class Paragraph(Parented):
         if style:
             run.style = style
         return run
+
+    def add_hyperlink(self, text=None, url=None, style=None):
+        """
+        Append a run to this paragraph containing *text* and having character
+        style identified by style ID *style*. *text* can contain tab
+        (``\\t``) characters, which are converted to the appropriate XML form
+        for a tab. *text* can also include newline (``\\n``) or carriage
+        return (``\\r``) characters, each of which is converted to a line
+        break.
+        """
+
+        h = self._p.add_hyperlink()
+        hyperlink = Hyperlink(h, self)
+
+        r = h.add_r()
+        run = Run(r, hyperlink)
+        
+        if text:
+            run.text = text
+        if style:
+            run.style = style
+
+        if url:
+            hyperlink.url = url
+        return hyperlink
 
     @property
     def alignment(self):


### PR DESCRIPTION
I continued robertdodd's work to implement the p.add_hyperlink() method:
- to add links to paragraphs
- to add multiple texts into a link
- style the link text(run)

Documentations are also available for the dev part.

> from docx import Document
> document = Document()
> p = document.add_paragraph('some text')
> link = p.add_hyperlink('google','http://www.google.com')
google
> link.add_run('run1')
  < docx.text.run.Run object at 0x7fec7cabe908>
> link.add_run('formatted').italic = True
3
