### PR TITLE
Add support for image title and alt text

### DIFF
--- a/docx/document.py
+++ b/docx/document.py
@@ -62,7 +62,7 @@ class Document(ElementProxy):
         """
         return self._body.add_paragraph(text, style)
 
-    def add_picture(self, image_path_or_stream, width=None, height=None):
+    def add_picture(self, image_path_or_stream, width=None, height=None, title=None, descr=None):
         """
         Return a new picture shape added in its own paragraph at the end of
         the document. The picture contains the image at
@@ -76,7 +76,7 @@ class Document(ElementProxy):
         is often the case.
         """
         run = self.add_paragraph().add_run()
-        return run.add_picture(image_path_or_stream, width, height)
+        return run.add_picture(image_path_or_stream, width, height, title=title, descr=descr)
 
     def add_section(self, start_type=WD_SECTION.NEW_PAGE):
         """

--- a/docx/oxml/shape.py
+++ b/docx/oxml/shape.py
@@ -58,7 +58,7 @@ class CT_Inline(BaseOxmlElement):
     graphic = OneAndOnlyOne('a:graphic')
 
     @classmethod
-    def new(cls, cx, cy, shape_id, pic):
+    def new(cls, cx, cy, shape_id, pic, title=None, descr=None):
         """
         Return a new ``<wp:inline>`` element populated with the values passed
         as parameters.
@@ -68,6 +68,11 @@ class CT_Inline(BaseOxmlElement):
         inline.extent.cy = cy
         inline.docPr.id = shape_id
         inline.docPr.name = 'Picture %d' % shape_id
+
+        if title:
+            inline.docPr.title = title
+        if descr:
+            inline.docPr.descr = descr
         inline.graphic.graphicData.uri = (
             'http://schemas.openxmlformats.org/drawingml/2006/picture'
         )
@@ -75,14 +80,14 @@ class CT_Inline(BaseOxmlElement):
         return inline
 
     @classmethod
-    def new_pic_inline(cls, shape_id, rId, filename, cx, cy):
+    def new_pic_inline(cls, shape_id, rId, filename, cx, cy, title=None, descr=None):
         """
         Return a new `wp:inline` element containing the `pic:pic` element
         specified by the argument values.
         """
         pic_id = 0  # Word doesn't seem to use this, but does not omit it
         pic = CT_Picture.new(pic_id, filename, rId, cx, cy)
-        inline = cls.new(cx, cy, shape_id, pic)
+        inline = cls.new(cx, cy, shape_id, pic, title=title, descr=descr)
         inline.graphic.graphicData._insert_pic(pic)
         return inline
 
@@ -109,7 +114,8 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
     """
     id = RequiredAttribute('id', ST_DrawingElementId)
     name = RequiredAttribute('name', XsdString)
-
+    title = OptionalAttribute('title', XsdString)
+    descr = OptionalAttribute('descr', XsdString)
 
 class CT_NonVisualPictureProperties(BaseOxmlElement):
     """

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -82,7 +82,7 @@ class DocumentPart(XmlPart):
         """
         return InlineShapes(self._element.body, self)
 
-    def new_pic_inline(self, image_descriptor, width, height):
+    def new_pic_inline(self, image_descriptor, width, height, title=None, descr=None):
         """
         Return a newly-created `w:inline` element containing the image
         specified by *image_descriptor* and scaled based on the values of
@@ -91,7 +91,7 @@ class DocumentPart(XmlPart):
         rId, image = self.get_or_add_image(image_descriptor)
         cx, cy = image.scaled_dimensions(width, height)
         shape_id, filename = self.next_id, image.filename
-        return CT_Inline.new_pic_inline(shape_id, rId, filename, cx, cy)
+        return CT_Inline.new_pic_inline(shape_id, rId, filename, cx, cy, title=title, descr=descr)
 
     @property
     def next_id(self):

--- a/docx/text/run.py
+++ b/docx/text/run.py
@@ -46,7 +46,7 @@ class Run(Parented):
         if clear is not None:
             br.clear = clear
 
-    def add_picture(self, image_path_or_stream, width=None, height=None):
+    def add_picture(self, image_path_or_stream, width=None, height=None, title=None, descr=None):
         """
         Return an |InlineShape| instance containing the image identified by
         *image_path_or_stream*, added to the end of this run.
@@ -59,7 +59,7 @@ class Run(Parented):
         (dpi) value specified in the image file, defaulting to 72 dpi if no
         value is specified, as is often the case.
         """
-        inline = self.part.new_pic_inline(image_path_or_stream, width, height)
+        inline = self.part.new_pic_inline(image_path_or_stream, width, height, title=title, descr=descr)
         self._r.add_drawing(inline)
         return InlineShape(inline)
 


### PR DESCRIPTION
Adding title and alt text to images makes documents more accessible for users that rely on screen readers.