### PR TITLE
Find key in styles dict without BabelFish translate.

### DIFF
--- a/docx/styles/styles.py
+++ b/docx/styles/styles.py
@@ -45,6 +45,10 @@ class Styles(ElementProxy):
         if style_elm is not None:
             return StyleFactory(style_elm)
 
+        style_elm = self._element.get_by_name(key)
+        if style_elm is not None:
+            return StyleFactory(style_elm)
+
         style_elm = self._element.get_by_id(key)
         if style_elm is not None:
             msg = (


### PR DESCRIPTION
Hi!

I got this exception:
```
    document.add_paragraph("Test", style="Heading 1")
  File "/usr/local/lib/python2.7/dist-packages/docx/document.py", line 63, in add_paragraph
    return self._body.add_paragraph(text, style)
  File "/usr/local/lib/python2.7/dist-packages/docx/blkcntnr.py", line 38, in add_paragraph
    paragraph.style = style
  File "/usr/local/lib/python2.7/dist-packages/docx/text/paragraph.py", line 111, in style
    style_or_name, WD_STYLE_TYPE.PARAGRAPH
  File "/usr/local/lib/python2.7/dist-packages/docx/parts/document.py", line 75, in get_style_id
    return self.styles.get_style_id(style_or_name, style_type)
  File "/usr/local/lib/python2.7/dist-packages/docx/styles/styles.py", line 113, in get_style_id
    return self._get_style_id_from_name(style_or_name, style_type)
  File "/usr/local/lib/python2.7/dist-packages/docx/styles/styles.py", line 147, in _get_style_id_from_name
    return self._get_style_id_from_style(self[style_name], style_type)
  File "/usr/local/lib/python2.7/dist-packages/docx/styles/styles.py", line 57, in __getitem__
    raise KeyError("no style with name '%s'" % key)
KeyError: u"no style with name 'Heading 1'"
```
when creating a template docx (contains only some own style specs)  with python-docx and try to fill with some data. I modified some style in LibreOffice5 and save in the appropriate format.

Python-docx created this style
```<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/>```
but LibreOffice overwrite it
```<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="Heading 1"/>```

So, I will check the raw key in styles dict after the BabelFish.ui2internal(key) does not find it.