### PR TITLE
Disallowing XML entity expansion

### DIFF
--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -14,7 +14,7 @@ from .ns import NamespacePrefixedTag, nsmap
 
 # configure XML parser
 element_class_lookup = etree.ElementNamespaceClassLookup()
-oxml_parser = etree.XMLParser(remove_blank_text=True)
+oxml_parser = etree.XMLParser(remove_blank_text=True, resolve_entities=False)
 oxml_parser.set_element_class_lookup(element_class_lookup)
 
 


### PR DESCRIPTION
Loading external DTDs is already disabled by default, but preventing entity expansion is the next step to make this library more secure.