### PR TITLE
Make xpath() match lxml's xpath() function signature

### DIFF
--- a/docx/oxml/xmlchemy.py
+++ b/docx/oxml/xmlchemy.py
@@ -742,13 +742,14 @@ class _OxmlElementBase(etree.ElementBase):
         """
         return serialize_for_reading(self)
 
-    def xpath(self, xpath_str):
+    def xpath(self, xpath_str, namespaces=None, *args, **kwargs):
         """
         Override of ``lxml`` _Element.xpath() method to provide standard Open
         XML namespace mapping (``nsmap``) in centralized location.
         """
         return super(BaseOxmlElement, self).xpath(
-            xpath_str, namespaces=nsmap
+            xpath_str, namespaces=nsmap if namespaces is None else namespaces,
+            *args, **kwargs
         )
 
     @property


### PR DESCRIPTION
Currently `OxmlElementBase.xpath` doesn't accept all of the same arguments as the `etree._Element.xpath` method it's overriding. This makes oxml etrees incompatible with third party libraries that know how to manipulate lxml etrees, like the awesome [pyquery library](https://pythonhosted.org/pyquery/).

This patch just makes sure that `xpath()` accepts and passes through all arguments to `super()`.

Here's an example of why it's handy to be compatible with pyquery, from a project I'm working on:

```
from pyquery import PyQuery
from docx import Document

doc = Document(path)
pq = PyQuery(doc.element, parser='xml')

# remove all indents
query('w|ind').remove()

# convert all underline to italics
for el in query('w|u'):
    el.tag = qn('w:i')
    el.attrib.clear()
```