### PR TITLE
east asia, chinese font family

### DIFF
--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -32,6 +32,7 @@ class CT_Fonts(BaseOxmlElement):
     """
     ascii = OptionalAttribute('w:ascii', ST_String)
     hAnsi = OptionalAttribute('w:hAnsi', ST_String)
+    eastAsia = OptionalAttribute('w:eastAsia', ST_String)
 
 
 class CT_Highlight(BaseOxmlElement):
@@ -137,6 +138,27 @@ class CT_RPr(BaseOxmlElement):
             return
         rFonts = self.get_or_add_rFonts()
         rFonts.ascii = value
+
+    @property
+    def rFonts_eastAsia(self):
+        """
+        The value of `w:rFonts/@w:eastAsia` or |None| if not present. Represents
+        the assigned typeface name. The rFonts element also specifies other
+        special-case typeface names; this method handles the case where just
+        the common name is required.
+        """
+        rFonts = self.rFonts
+        if rFonts is None:
+            return None
+        return rFonts.eastAsia
+
+    @rFonts_eastAsia.setter
+    def rFonts_eastAsia(self, value):
+        if value is None:
+            self._remove_rFonts()
+            return
+        rFonts = self.get_or_add_rFonts()
+        rFonts.eastAsia = value
 
     @property
     def rFonts_hAnsi(self):

--- a/docx/text/font.py
+++ b/docx/text/font.py
@@ -196,6 +196,7 @@ class Font(ElementProxy):
         rPr = self._element.get_or_add_rPr()
         rPr.rFonts_ascii = value
         rPr.rFonts_hAnsi = value
+        rPr.rFonts_eastAsia = value
 
     @property
     def no_proof(self):


### PR DESCRIPTION
My test code is like this:
    styles = document.styles
    s1 = styles.add_style('s1', WD_STYLE_TYPE.PARAGRAPH)
    s1.font.size = Pt(40)
    s1.font.name = u'楷体_GB2312'
    document.add_paragraph(u'中文内容', style = s1)

The chinese font family name has no effect.
So I create a docx file with the goal content, unzip it and compare the xml with that generated by python-docx. I find that the difference is the following fragment:

<w:rFonts w:eastAsia="楷体_GB2312" w:asciiTheme="minorAscii" w:hAnsiTheme="minorAscii"/></w:rPr>

That's why I add the property 'eastAsia'.

