### PR TITLE
Fixed failure caused by "python -OO"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /docs/.build/
 /*.egg-info
 *.pyc
+*.pyo
 _scratch/
 Session.vim
 /.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements.txt
 # command to run tests, e.g. python setup.py test
-script:  py.test
+script:
+  - py.test
+  - python -OO -m py.test tests/test_enum.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -r requirements.txt
 # command to run tests, e.g. python setup.py test
-script:
-  - py.test
-  - python -OO -m py.test tests/test_enum.py
+script: py.test
+
+# run python -OO on certain versions only, 3.3 and 3.5 cannot handle this
+matrix:
+  include:
+  - python: "2.6"
+    script: python -OO -m py.test tests/test_enum.py
+  - python: "2.7"
+    script: python -OO -m py.test tests/test_enum.py
+  - python: "3.4"
+    script: python -OO -m py.test tests/test_enum.py

--- a/docx/enum/base.py
+++ b/docx/enum/base.py
@@ -60,6 +60,8 @@ class _DocsPageFormatter(object):
             cls_docstring = self._clsdict['__doc__']
         except KeyError:
             cls_docstring = ''
+        if None == cls_docstring:
+            cls_docstring = ''
         return textwrap.dedent(cls_docstring).strip()
 
     def _member_def(self, member):

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -77,6 +77,9 @@ class DescribeEnumeration(object):
     def it_can_be_referred_to_by_a_convenience_alias_if_defined(self):
         assert BARFOO is FOOBAR  # noqa
 
+    def it_provides_doc(self):
+        assert(FOOBAR.__docs_rst__)
+
 
 class DescribeEnumValue(object):
 


### PR DESCRIPTION
Some python packaging projects like kivy-sdk-packager use "-OO" flags which cause runtime exception.
https://github.com/strakh/kivy-sdk-packager/blob/master/osx/package-app.sh#L35