### PR TITLE
[feature]add add_chart for docx using chart from python-pptx.

### DIFF
--- a/docx/document.py
+++ b/docx/document.py
@@ -100,6 +100,20 @@ class Document(ElementProxy):
         table.style = style
         return table
 
+    def add_chart(self, chart_type, x, y, cx, cy, chart_data):
+        """
+        Add a new chart of *chart_type* to the slide, positioned at (*x*,
+        *y*), having size (*cx*, *cy*), and depicting *chart_data*.
+        *chart_type* is one of the :ref:`XlChartType` enumeration values.
+        *chart_data* is a |ChartData| object populated with the categories
+        and series values for the chart. Note that a |GraphicFrame| shape
+        object is returned, not the |Chart| object contained in that graphic
+        frame shape. The chart object may be accessed using the :attr:`chart`
+        property of the returned |GraphicFrame| object.
+        """
+        run = self.add_paragraph().add_run()
+        return run.add_chart(chart_type, x, y, cx, cy, chart_data)
+
     @property
     def core_properties(self):
         """

--- a/docx/opc/package.py
+++ b/docx/opc/package.py
@@ -8,7 +8,7 @@ writing presentations to and from a .pptx file.
 from __future__ import absolute_import, print_function, unicode_literals
 
 from .constants import RELATIONSHIP_TYPE as RT
-from .packuri import PACKAGE_URI
+from .packuri import PACKAGE_URI, PackURI
 from .part import PartFactory
 from .parts.coreprops import CorePropertiesPart
 from .pkgreader import PackageReader
@@ -85,6 +85,21 @@ class OpcPackage(object):
 
         for part in walk_parts(self):
             yield part
+
+    def next_partname(self, tmpl):
+        """
+        Return a |PackURI| instance representing the next available partname
+        matching *tmpl*, which is a printf (%)-style template string
+        containing a single replacement item, a '%d' to be used to insert the
+        integer portion of the partname. Example: '/word/slides/slide%d.xml'
+        """
+        tmpl = tmpl.replace('/ppt', '/word')
+        partnames = [part.partname for part in self.iter_parts()]
+        for n in range(1, len(partnames)+2):
+            candidate_partname = tmpl % n
+            if candidate_partname not in partnames:
+                return PackURI(candidate_partname)
+        raise Exception('ProgrammingError: ran out of candidate_partnames')
 
     def load_rel(self, reltype, target, rId, is_external=False):
         """

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -96,7 +96,7 @@ from .shape import (
     CT_Blip, CT_BlipFillProperties, CT_GraphicalObject,
     CT_GraphicalObjectData, CT_Inline, CT_NonVisualDrawingProps, CT_Picture,
     CT_PictureNonVisual, CT_Point2D, CT_PositiveSize2D, CT_ShapeProperties,
-    CT_Transform2D
+    CT_Transform2D, CT_Chart
 )
 register_element_cls('a:blip',        CT_Blip)
 register_element_cls('a:ext',         CT_PositiveSize2D)
@@ -112,6 +112,7 @@ register_element_cls('pic:spPr',      CT_ShapeProperties)
 register_element_cls('wp:docPr',      CT_NonVisualDrawingProps)
 register_element_cls('wp:extent',     CT_PositiveSize2D)
 register_element_cls('wp:inline',     CT_Inline)
+register_element_cls('c:chart',     CT_Chart)
 
 from .styles import CT_LatentStyles, CT_LsdException, CT_Style, CT_Styles
 register_element_cls('w:basedOn',        CT_String)

--- a/docx/oxml/shape.py
+++ b/docx/oxml/shape.py
@@ -46,6 +46,7 @@ class CT_GraphicalObjectData(BaseOxmlElement):
     ``<a:graphicData>`` element, container for the XML of a DrawingML object
     """
     pic = ZeroOrOne('pic:pic')
+    cChart = ZeroOrOne('c:chart')
     uri = RequiredAttribute('uri', XsdToken)
 
 
@@ -101,6 +102,33 @@ class CT_Inline(BaseOxmlElement):
             '</wp:inline>' % nsdecls('wp', 'a', 'pic', 'r')
         )
 
+    @classmethod
+    def new_chart_inline(cls, shape_id, rId, x, y, cx, cy):
+        """
+        Return a new ``<wp:inline>`` element populated with the values passed
+        as parameters.
+        """
+        inline = parse_xml(cls._chart_xml())
+        inline.extent.cx = cx
+        inline.extent.cy = cy
+        chart = CT_Chart.new(rId)
+        inline.graphic.graphicData._insert_cChart(chart)
+        return inline
+
+    @classmethod
+    def _chart_xml(cls):
+        return (
+            '<wp:inline %s>\n'
+            '  <wp:extent/>\n'
+            '  <wp:effectExtent l="0" t="0" r="0" b="0"/>\n'
+            '  <wp:docPr id="1" name="Chart 1"/>\n'
+            '  <wp:cNvGraphicFramePr/>\n'
+            '  <a:graphic %s>\n'
+            '    <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"/>\n'
+            '  </a:graphic>\n'
+            '</wp:inline>' % (nsdecls('wp', 'a'), nsdecls('a'))
+        )
+
 
 class CT_NonVisualDrawingProps(BaseOxmlElement):
     """
@@ -116,6 +144,28 @@ class CT_NonVisualPictureProperties(BaseOxmlElement):
     ``<pic:cNvPicPr>`` element, specifies picture locking and resize
     behaviors.
     """
+
+class CT_Chart(BaseOxmlElement):
+    """
+    ``<c:chart>`` element, a DrawingML picture
+    """
+
+    @classmethod
+    def new(cls, rId):
+        """
+        Return a new ``<c:chart>`` element populated with the minimal
+        contents required to define a viable chart element, based on the
+        values passed as parameters.
+        """
+        chart = parse_xml(cls._chart_xml(rId))
+        chart.id = rId
+        return chart
+
+    @classmethod
+    def _chart_xml(cls, rId):
+        return (
+            '<c:chart %s r:id="%s"/>\n'% (nsdecls('c', 'r'), rId)
+        )
 
 
 class CT_Picture(BaseOxmlElement):

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -17,7 +17,7 @@ from ..shape import InlineShapes
 from ..shared import lazyproperty
 from .settings import SettingsPart
 from .styles import StylesPart
-
+from pptx.parts.chart import ChartPart
 
 class DocumentPart(XmlPart):
     """
@@ -57,6 +57,15 @@ class DocumentPart(XmlPart):
         rId = self.relate_to(image_part, RT.IMAGE)
         return rId, image_part.image
 
+    def get_or_add_chart(self, chart_type, x, y, cx, cy, chart_data):
+        """
+        Return an (rId, chart) 2-tuple for the chart.
+        Access the chart properties like description in python-pptx documents.
+        """
+        chart_part = ChartPart.new(chart_type, chart_data, self.package)
+        rId = self.relate_to(chart_part, RT.CHART)
+        return rId, chart_part.chart
+
     def get_style(self, style_id, style_type):
         """
         Return the style in this document matching *style_id*. Returns the
@@ -93,6 +102,15 @@ class DocumentPart(XmlPart):
         cx, cy = image.scaled_dimensions(width, height)
         shape_id, filename = self.next_id, image.filename
         return CT_Inline.new_pic_inline(shape_id, rId, filename, cx, cy)
+
+    def new_chart_inline(self, chart_type, x, y, cx, cy, chart_data):
+        """
+        Return a newly-created `w:inline` element containing the chart
+        with position *x* and *y* and width *cx* and height *y*
+        """
+        rId, chart = self.get_or_add_chart(chart_type, x, y, cx, cy, chart_data)
+        shape_id = self.next_id
+        return CT_Inline.new_chart_inline(shape_id, rId, x, y, cx, cy), chart
 
     @property
     def next_id(self):

--- a/docx/text/run.py
+++ b/docx/text/run.py
@@ -46,6 +46,15 @@ class Run(Parented):
         if clear is not None:
             br.clear = clear
 
+    def add_chart(self, chart_type, x, y, cx, cy, chart_data):
+        """
+        Return an |InlineShape| instance containing the chart, added to the
+        end of this run.
+        """
+        inline, chart = self.part.new_chart_inline(chart_type, x, y, cx, cy, chart_data)
+        self._r.add_drawing(inline)
+        return chart
+
     def add_picture(self, image_path_or_stream, width=None, height=None):
         """
         Return an |InlineShape| instance containing the image identified by

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ LICENSE = text_of('LICENSE')
 PACKAGES = find_packages(exclude=['tests', 'tests.*'])
 PACKAGE_DATA = {'docx': ['templates/*']}
 
-INSTALL_REQUIRES = ['lxml>=2.3.2']
+INSTALL_REQUIRES = ['lxml>=2.3.2', 'python-pptx>=0.6.5']
 TEST_SUITE = 'tests'
 TESTS_REQUIRE = ['behave', 'mock', 'pyparsing', 'pytest']
 


### PR DESCRIPTION
Hi, I create a new feature branch to add new feature: add_chart for docx.

The add_chart method allow us to add chart from python-pptx to docx. I request to merge to master branch and release as v0.8.7 or something.

Best wishes.