### PR TITLE
Fix errors with some type of images

### DIFF
--- a/docx/image/helpers.py
+++ b/docx/image/helpers.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, division, print_function
 
 from struct import Struct
 
+import logging
+
 from .exceptions import UnexpectedEndOfFileError
 
 
@@ -93,5 +95,10 @@ class StreamReader(object):
         return self._unpack_item(struct, base, offset)
 
     def _unpack_item(self, struct, base, offset):
-        bytes_ = self._read_bytes(struct.size, base, offset)
+        try:
+            bytes_ = self._read_bytes(struct.size, base, offset)
+        except UnexpectedEndOfFileError:
+            logging.error('Error while reading bytes with struct size - {}, base - {}, offset - {}. '
+                          'This bytes are replaced by an empty string.'.format(struct.size, base, offset))
+            return ''
         return struct.unpack(bytes_)[0]


### PR DESCRIPTION
![6a0d4f54-9228-473d-9652-bda29238e94e](https://cloud.githubusercontent.com/assets/13443126/25943911/1dc0897a-364a-11e7-88c2-457e5e2fa220.jpeg)
Error with this image ('UnexpectedEndOfFileError' while reading exif data), I am just replace unreadable bytes empty string.