### PR TITLE
Added font property to paragraph

### DIFF
--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -53,6 +53,7 @@ class CT_PPr(BaseOxmlElement):
     spacing = ZeroOrOne('w:spacing', successors=_tag_seq[22:])
     ind = ZeroOrOne('w:ind', successors=_tag_seq[23:])
     jc = ZeroOrOne('w:jc', successors=_tag_seq[27:])
+    rPr = ZeroOrOne('w:rPr', successors=_tag_seq[34:])
     sectPr = ZeroOrOne('w:sectPr', successors=_tag_seq[35:])
     del _tag_seq
 

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -10,7 +10,7 @@ from __future__ import (
 
 from ..enum.style import WD_STYLE_TYPE
 from .parfmt import ParagraphFormat
-from .run import Run
+from .run import Run, Font
 from ..shared import Parented
 
 
@@ -83,7 +83,18 @@ class Paragraph(Parented):
         properties for this paragraph, such as line spacing and indentation.
         """
         return ParagraphFormat(self._element)
-
+    
+    @property
+    def font(self):
+        """
+        The |Font| object providing access to the character formatting
+        properties for this paragraph, such as font name and size.
+        """
+        pPr = self._element.pPr
+        if pPr is None:
+            return None
+        return Font(pPr)
+        
     @property
     def runs(self):
         """


### PR DESCRIPTION
Paragraphs <w:pPr> can include the same formatting as runs using <w:rPr> members. This patches the CT_PPr object to map the rPr member and adds a font member to Paragraph to access it, similar to how it works for runs
and the font member. It is functional as far as I know, but no additions to the testing modules at this point.