### PR TITLE
Added Canon EOS Jpeg format

### DIFF
--- a/docx/image/__init__.py
+++ b/docx/image/__init__.py
@@ -26,4 +26,5 @@ SIGNATURES = (
     (Tiff, 0, b'MM\x00*'),  # big-endian (Motorola) TIFF
     (Tiff, 0, b'II*\x00'),  # little-endian (Intel) TIFF
     (Bmp,  0, b'BM'),
+    (Jfif, 0, b'\xFF\xD8\xFF\xE2'),  # CANNON EOS JPEG FILE
 )


### PR DESCRIPTION
The Canon EOS Jpeg format uses a custom signature Canon EOS Jpeg format
There are several other closely realted formats that should be added to docx/image/__init__.py