### PR TITLE
Deprecated style_id in quickstart.rst

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -222,16 +222,16 @@ a paragraph at once. It's a lot like CSS styles if you know what those are.
 
 You can apply a paragraph style right when you create a paragraph::
 
-    document.add_paragraph('Lorem ipsum dolor sit amet.', style='ListBullet')
+    document.add_paragraph('Lorem ipsum dolor sit amet.', style='List Bullet')
 
 This particular style causes the paragraph to appear as a bullet, a very handy
 thing. You can also apply a style afterward. These two lines are equivalent to
 the one above::
 
     paragraph = document.add_paragraph('Lorem ipsum dolor sit amet.')
-    paragraph.style = 'ListBullet'
+    paragraph.style = 'List Bullet'
 
-The style is specified using its style name.
+The style is specified using its style name, 'List Bullet' in this case.
 
 PS: Style lookup by style_id is deprecated. Use style name as key instead.
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -231,12 +231,9 @@ the one above::
     paragraph = document.add_paragraph('Lorem ipsum dolor sit amet.')
     paragraph.style = 'ListBullet'
 
-The style is specified using its style ID, 'ListBullet' in this example.
-Generally, the style ID is formed by removing the spaces in the style name as
-it appears in the Word user interface (UI). So the style 'List Number 3'
-would be specified as ``'ListNumber3'``. However, note that if you are using
-a localized version of Word, the style ID may be derived from the English
-style name and may not correspond so neatly to its style name in the Word UI.
+The style is specified using its style name.
+
+PS: Style lookup by style_id is deprecated. Use style name as key instead.
 
 
 Applying bold and italic


### PR DESCRIPTION
Corrected a deprecated usage in quickstart guide. This is my first contribute to an open-source project. Hope I was okay :)