### PR TITLE
Extend flexibility of api.py

### DIFF
--- a/docx/api.py
+++ b/docx/api.py
@@ -23,7 +23,7 @@ def Document(docx=None):
     """
     docx = _default_docx_path() if docx is None else docx
     document_part = Package.open(docx).main_document_part
-    if document_part.content_type != CT.WML_DOCUMENT_MAIN:
+    if document_part.content_type not in [CT.WML_DOCUMENT_MAIN, 'application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml', 'application/vnd.ms-word.document.macroEnabled.main+xml']:
         tmpl = "file '%s' is not a Word file, content type is '%s'"
         raise ValueError(tmpl % (docx, document_part.content_type))
     return document_part.document


### PR DESCRIPTION
Along with my proposed change to __init__.py, these changes should allow support for .dotx (MS Word Template) files as well as .docx.