### PR TITLE
Make rPr accessible from pPr

### DIFF
--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -57,6 +57,7 @@ class CT_PPr(BaseOxmlElement):
     spacing = ZeroOrOne('w:spacing', successors=_tag_seq[22:])
     ind = ZeroOrOne('w:ind', successors=_tag_seq[23:])
     jc = ZeroOrOne('w:jc', successors=_tag_seq[27:])
+    rPr = ZeroOrOne('w:rPr', successors=_tag_seq[34:])
     sectPr = ZeroOrOne('w:sectPr', successors=_tag_seq[35:])
     del _tag_seq
 


### PR DESCRIPTION
This is useful when styling paragraph marks, e.g. bullet list points -- which can, in fact, have a different style each; otherwise they would just get the default document style.