### PR TITLE
detect beginning of new row. if last row is incomplete, add empty cells.

### DIFF
--- a/docx/table.py
+++ b/docx/table.py
@@ -168,6 +168,11 @@ class Table(Parented):
         col_count = self._column_count
         cells = []
         for tc in self._tbl.iter_tcs():
+            previousRowIncomplete = (tc.left == 0) and (len(cells) % col_count > 0)
+            if previousRowIncomplete:
+                missingCellCount = col_count - (len(cells) % col_count)
+                for i in range(0, missingCellCount):
+                    cells.append(_Cell("w:tc", self))
             for grid_span_idx in range(tc.grid_span):
                 if tc.vMerge == ST_Merge.CONTINUE:
                     cells.append(cells[-col_count])

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -69,6 +69,11 @@ class DescribeTable(object):
         row_cells = table.row_cells(row_idx)
         assert row_cells == expected_cells
 
+    def it_detects_the_beginning_of_new_rows(self, inconsistet_col_span_fixture):
+        table, row_idx, col_idx, expected_text = inconsistet_col_span_fixture
+        cell = table.cell(row_idx, col_idx)
+        assert cell.text == expected_text
+
     def it_knows_its_alignment_setting(self, alignment_get_fixture):
         table, expected_value = alignment_get_fixture
         assert table.alignment == expected_value
@@ -268,6 +273,20 @@ class DescribeTable(object):
         row_idx = 1
         expected_cells = [3, 4, 5]
         return table, row_idx, expected_cells
+
+    @pytest.fixture
+    def inconsistet_col_span_fixture(self):
+        # the second row is missing one column
+        tbl_cxml = 'w:tbl/(w:tblGrid/(w:gridCol,w:gridCol,w:gridCol)' \
+            + ',w:tr/(w:tc,w:tc/w:tcPr/w:gridSpan{w:val=2})' \
+            + ',w:tr/(w:tc,w:tc/w:tcPr/w:gridSpan{w:val=1})' \
+            + ',w:tr/(w:tc/w:p/w:r/w:t"correct cell",w:tc/w:tcPr/w:gridSpan{w:val=2})' \
+            + ')'
+        table = Table(element(tbl_cxml), None)
+        row_idx = 2
+        col_idx = 0
+        expected_text = "correct cell"
+        return table, row_idx, col_idx, expected_text
 
     @pytest.fixture
     def style_get_fixture(self, part_prop_):


### PR DESCRIPTION
I found that some tables in MS-Word created documents have inconsistend grid_span attributes in a row (not matching the tblGrid's gridCol element count).

When accessing the ._cells property of such a table, it will not consider the row/column definition of the xml but just count the cells and assume that the cell count per row and all grid_span attributes are consistent with the tblGrid specification.
In my case there were 7 columns in the table but one row contained only grid_span attribues of 1 + 1 + 2 + 2 = 6. The next row and all succeeding rows would get partly wrapped around and were broken.

This merge request fixes the issue by detecting a row's start (see #232) and then filling any incomplete row with empty cells if necessary. Unit test is included.