### PR TITLE
use caching for faster table cell access

### DIFF
--- a/docx/table.py
+++ b/docx/table.py
@@ -12,12 +12,12 @@ from .oxml.simpletypes import ST_Merge
 from .shared import Inches, lazyproperty, Parented
 
 
-class Table(Parented):
+class _Table(Parented):
     """
     Proxy class for a WordprocessingML ``<w:tbl>`` element.
     """
     def __init__(self, tbl, parent):
-        super(Table, self).__init__(parent)
+        super(_Table, self).__init__(parent)
         self._element = self._tbl = tbl
 
     def add_column(self, width):
@@ -467,3 +467,23 @@ class _Rows(Parented):
         Reference to the |Table| object this row collection belongs to.
         """
         return self._parent.table
+
+
+class Table(_Table):
+    def __init__(self,*args,**kwargs):
+        super(Table,self).__init__(*args,**kwargs)
+        self.__cells = None
+
+    @property
+    def _cells(self):
+        if self.__cells is not None:
+            if len(self.rows) != self.__row_count:
+                self.__cells = None
+            if self._column_count != self.__column_count:
+                self.__cells = None
+        if self.__cells is None:
+            self.__column_count = self._column_count
+            self.__row_count = len(self.rows)
+            self.__cells = super(Table,self)._cells
+        return self.__cells
+


### PR DESCRIPTION
Acessing table data is really really slow by default, i figured out that the bottleneck is the property _cells of the Table class.
I created now a quick Child Class which reimplements the _cells property using caching which speeds up the access by a magnitude of 290 for my table with about 200 rows and 12 columns when accessing the first column of each row.

before it took: 29 s
now it takes about:  100ms 

