### PR TITLE
read eastAsia font name

### DIFF
--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -32,6 +32,7 @@ class CT_Fonts(BaseOxmlElement):
     """
     ascii = OptionalAttribute('w:ascii', ST_String)
     hAnsi = OptionalAttribute('w:hAnsi', ST_String)
+    eastAsia = OptionalAttribute('w:eastAsia', ST_String)
 
 
 class CT_Highlight(BaseOxmlElement):
@@ -137,6 +138,28 @@ class CT_RPr(BaseOxmlElement):
             return
         rFonts = self.get_or_add_rFonts()
         rFonts.ascii = value
+
+    @property
+    def rFonts_eastAsia(self):
+        """
+        The value of `w:rFonts/@w:ascii` or |None| if not present. Represents
+        the assigned typeface name. The rFonts element also specifies other
+        special-case typeface names; this method handles the case where just
+        the common name is required.
+        """
+        rFonts = self.rFonts
+        if rFonts is None:
+            return None
+        return rFonts.eastAsia
+
+    
+    @rFonts_eastAsia.setter
+    def rFonts_eastAsia(self, value):
+        if value is None:
+            self._remove_rFonts()
+            return
+        rFonts = self.get_or_add_rFonts()
+        rFonts.eastAsia = value
 
     @property
     def rFonts_hAnsi(self):

--- a/docx/text/font.py
+++ b/docx/text/font.py
@@ -199,9 +199,9 @@ class Font(ElementProxy):
     def name(self, value):
         rPr = self._element.get_or_add_rPr()
         if isinstance(value,dict):
-            rPr.rFonts_ascii = value['ascii']
-            rPr.rFonts_hAnsi = value['hAnsi']
-            rPr.rFonts_eastAsia = value['eastAsia']
+            rPr.rFonts_ascii = value.get('ascii')
+            rPr.rFonts_hAnsi = value.get('hAnsi')
+            rPr.rFonts_eastAsia = value.get('eastAsia')
         else:
             rPr.rFonts_ascii = value
             rPr.rFonts_hAnsi = value

--- a/docx/text/font.py
+++ b/docx/text/font.py
@@ -189,19 +189,24 @@ class Font(ElementProxy):
         rPr = self._element.rPr
         if rPr is None:
             return None
-        rFonts_willReturn = rPr.rFonts_ascii
-        if rFonts_willReturn is None:
-            rFonts_willReturn = rPr.rFonts_hAnsi
-        if rFonts_willReturn is None:
-            rFonts_willReturn = rPr.rFonts_eastAsia
-        return rFonts_willReturn
+        return {
+            'ascii' : rPr.rFonts_ascii,
+            'hAnsi' : rPr.rFonts_hAnsi,
+            'eastAsia' : rPr.rFonts_eastAsia
+            }
 
     @name.setter
     def name(self, value):
         rPr = self._element.get_or_add_rPr()
-        rPr.rFonts_ascii = value
-        rPr.rFonts_hAnsi = value
-        rPr.rFonts_eastAsia = value
+        if isinstance(value,dict):
+            rPr.rFonts_ascii = value['ascii']
+            rPr.rFonts_hAnsi = value['hAnsi']
+            rPr.rFonts_eastAsia = value['eastAsia']
+        else:
+            rPr.rFonts_ascii = value
+            rPr.rFonts_hAnsi = value
+            rPr.rFonts_eastAsia = value
+                
 
     @property
     def no_proof(self):

--- a/docx/text/font.py
+++ b/docx/text/font.py
@@ -189,13 +189,19 @@ class Font(ElementProxy):
         rPr = self._element.rPr
         if rPr is None:
             return None
-        return rPr.rFonts_ascii
+        rFonts_willReturn = rPr.rFonts_ascii
+        if rFonts_willReturn is None:
+            rFonts_willReturn = rPr.rFonts_hAnsi
+        if rFonts_willReturn is None:
+            rFonts_willReturn = rPr.rFonts_eastAsia
+        return rFonts_willReturn
 
     @name.setter
     def name(self, value):
         rPr = self._element.get_or_add_rPr()
         rPr.rFonts_ascii = value
         rPr.rFonts_hAnsi = value
+        rPr.rFonts_eastAsia = value
 
     @property
     def no_proof(self):


### PR DESCRIPTION
font.name will return a dict
```python
{'ascii': 'Times New Roman', 'hAnsi': 'Times New Roman', 'eastAsia': '宋 体'}
```
or set name
```python
styles = document.styles
s1 = styles.add_style('s1', WD_STYLE_TYPE.PARAGRAPH)
s1.font.size = Pt(40)
s1.font.name = '宋体' #use one param like before or
s1.font.name = {'ascii': 'Times New Roman', 'hAnsi': 'Times New Roman', 'eastAsia': '宋体'}
```