### PR TITLE
Table: feature : allow table looking (header row/col, footer row/col, bands) modification

### DIFF
--- a/docs/dev/analysis/features/text/hyperlink.rst
+++ b/docs/dev/analysis/features/text/hyperlink.rst
@@ -1,0 +1,301 @@
+
+Hyperlink
+=========
+
+Word allows hyperlinks to be placed in a document.
+
+The target of a hyperlink may be external, such as a web site, or internal,
+to another location in the document.
+
+A hyperlink can contain multiple runs of text, each with its own distinct
+text formatting (font).
+
+
+Candidate protocol
+------------------
+
+An external hyperlink has an address and an optional anchor. An internal
+hyperlink has only an anchor.
+
+.. highlight:: python
+
+**Add the external hyperlink** `http://us.com#about`::
+
+    >>> hyperlink = paragraph.add_hyperlink('About', address='http://us.com', anchor='about')
+    >>> hyperlink
+    <docx.text.hyperlink.Hyperlink at 0x7f...>
+    >>> hyperlink.text
+    'About'
+    >>> hyperlink.address
+    'http://us.com'
+    >>> hyperlink.anchor
+    'about'
+
+**Add an internal hyperlink (to a bookmark)**::
+
+    >>> hyperlink = paragraph.add_hyperlink('Section 1', anchor='Section_1')
+    >>> hyperlink.text
+    'Section 1'
+    >>> hyperlink.anchor
+    'Section_1'
+    >>> hyperlink.address
+    None
+
+**Modify hyperlink properties**::
+
+    >>> hyperlink.text = 'Froogle'
+    >>> hyperlink.text
+    'Froogle'
+    >>> hyperlink.address = 'mailto:info@froogle.com?subject=sup dawg?'
+    >>> hyperlink.address
+    'mailto:info@froogle.com?subject=sup%20dawg%3F'
+    >>> hyperlink.anchor = None
+    >>> hyperlink.anchor
+    None
+
+**Add additional runs to a hyperlink**::
+
+    >>> hyperlink.text = 'A '
+    >>> # .insert_run inserts a new run at idx, defaults to idx=-1
+    >>> hyperlink.insert_run(' link').bold = True
+    >>> hyperlink.insert_run('formatted', idx=1).bold = True
+    >>> hyperlink.text
+    'A formatted link'
+    >>> [r for r in hyperlink.iter_runs()]
+    [<docx.text.run.Run at 0x7fa...>,
+     <docx.text.run.Run at 0x7fb...>,
+     <docx.text.run.Run at 0x7fc...>]
+
+**Iterate over the run-level items a paragraph contains**::
+
+    >>> paragraph = document.add_paragraph('A paragraph having a link to: ')
+    >>> paragraph.add_hyperlink(text='github', address='http://github.com')
+    >>> [item for item in paragraph.iter_run_level_items()]:
+    [<docx.text.paragraph.Run at 0x7fd...>, <docx.text.paragraph.Hyperlink at 0x7fe...>]
+
+**Paragraph.text now includes text contained in a hyperlink**::
+
+    >>> paragraph.text
+    'A paragraph having a link to: github'
+
+
+Word Behaviors
+--------------
+
+* What are the semantics of the w:history attribute on w:hyperlink? I'm
+  suspecting this indicates whether the link should show up blue (unvisited)
+  or purple (visited). I'm inclined to think we need that as a read/write
+  property on hyperlink. We should see what the MS API does on this count.
+
+* We probably need to enforce some character-set restrictions on w:anchor.
+  Word doesn't seem to like spaces or hyphens, for example. The simple type
+  ST_String doesn't look like it takes care of this.
+
+* We'll need to test URL escaping of special characters like spaces and
+  question marks in Hyperlink.address.
+
+* What does Word do when loading a document containing an internal hyperlink
+  having an anchor value that doesn't match an existing bookmark? We'll want
+  to know because we're sure to get support inquiries from folks who don't
+  match those up and wonder why they get a repair error or whatever.
+
+
+Specimen XML
+------------
+
+.. highlight:: xml
+
+
+External links
+~~~~~~~~~~~~~~
+
+The address (URL) of an external hyperlink is stored in the document.xml.rels
+file, keyed by the w:hyperlink@r:id attribute::
+
+    <w:p>
+      <w:r>
+        <w:t xml:space="preserve">This is an external link to </w:t>
+      </w:r>
+      <w:hyperlink r:id="rId4">
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t>Google</w:t>
+        </w:r>
+      </w:hyperlink>
+    </w:p>
+
+... mapping to relationship in document.xml.rels::
+
+    <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+      <Relationship Id="rId4" Mode="External" Type="http://..." Target="http://google.com/"/>
+    </Relationships>
+
+A hyperlink can contain multiple runs of text (and a whole lot of other
+stuff, including nested hyperlinks, at least as far as the schema indicates)::
+
+    <w:p>
+      <w:hyperlink r:id="rId2">
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t xml:space="preserve">A hyperlink containing an </w:t>
+        </w:r>
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+            <w:i/>
+          </w:rPr>
+          <w:t>italicized</w:t>
+        </w:r>
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t xml:space="preserve"> word</w:t>
+        </w:r>
+      </w:hyperlink>
+    </w:p>
+
+
+Internal links
+~~~~~~~~~~~~~~
+
+An internal link provides "jump to another document location" behavior in the
+Word UI. An internal link is distinguished by the absence of an r:id
+attribute. In this case, the w:anchor attribute is required. The value of the
+anchor attribute is the name of a bookmark in the document.
+
+Example::
+
+    <w:p>
+      <w:r>
+        <w:t xml:space="preserve">See </w:t>
+      </w:r>
+      <w:hyperlink w:anchor="Section_4">
+        <w:r>
+          <w:rPr>
+            <w:rStyle w:val="Hyperlink"/>
+          </w:rPr>
+          <w:t>Section 4</w:t>
+        </w:r>
+      </w:hyperlink>
+      <w:r>
+        <w:t xml:space="preserve"> for more details.</w:t>
+      </w:r>
+    </w:p>
+
+... referring to this bookmark elsewhere in the document::
+
+    <w:p>
+      <w:bookmarkStart w:id="0" w:name="Section_4"/>
+        <w:r>
+          <w:t>Section 4</w:t>
+        </w:r>
+      <w:bookmarkEnd w:id="0"/>
+    </w:p>
+
+
+Schema excerpt
+--------------
+
+.. highlight:: xml
+
+::
+
+    <xsd:complexType name="CT_P">
+      <xsd:sequence>
+        <xsd:element name="pPr" type="CT_PPr" minOccurs="0"/>
+        <xsd:group   ref="EG_PContent"        minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="rsidRPr"      type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidR"        type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidDel"      type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidP"        type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidRDefault" type="ST_LongHexNumber"/>
+    </xsd:complexType>
+
+    <xsd:group name="EG_PContent">  <!-- denormalized -->
+      <xsd:choice>
+        <xsd:element name="r"         type="CT_R"/>
+        <xsd:element name="hyperlink" type="CT_Hyperlink"/>
+        <xsd:element name="fldSimple" type="CT_SimpleField"/>
+        <xsd:element name="sdt"       type="CT_SdtRun"/>
+        <xsd:element name="customXml" type="CT_CustomXmlRun"/>
+        <xsd:element name="smartTag"  type="CT_SmartTagRun"/>
+        <xsd:element name="dir"       type="CT_DirContentRun"/>
+        <xsd:element name="bdo"       type="CT_BdoContentRun"/>
+        <xsd:element name="subDoc"    type="CT_Rel"/>
+        <xsd:group    ref="EG_RunLevelElts"/>
+      </xsd:choice>
+    </xsd:group>
+
+    <xsd:complexType name="CT_Hyperlink">
+      <xsd:group ref="EG_PContent" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:attribute name="tgtFrame"    type="s:ST_String"/>
+      <xsd:attribute name="tooltip"     type="s:ST_String"/>
+      <xsd:attribute name="docLocation" type="s:ST_String"/>
+      <xsd:attribute name="history"     type="s:ST_OnOff"/>
+      <xsd:attribute name="anchor"      type="s:ST_String"/>
+      <xsd:attribute  ref="r:id"/>
+    </xsd:complexType>
+
+    <xsd:group name="EG_RunLevelElts">
+      <xsd:choice>
+        <xsd:element name="proofErr"                    type="CT_ProofErr"/>
+        <xsd:element name="permStart"                   type="CT_PermStart"/>
+        <xsd:element name="permEnd"                     type="CT_Perm"/>
+        <xsd:element name="bookmarkStart"               type="CT_Bookmark"/>
+        <xsd:element name="bookmarkEnd"                 type="CT_MarkupRange"/>
+        <xsd:element name="moveFromRangeStart"          type="CT_MoveBookmark"/>
+        <xsd:element name="moveFromRangeEnd"            type="CT_MarkupRange"/>
+        <xsd:element name="moveToRangeStart"            type="CT_MoveBookmark"/>
+        <xsd:element name="moveToRangeEnd"              type="CT_MarkupRange"/>
+        <xsd:element name="commentRangeStart"           type="CT_MarkupRange"/>
+        <xsd:element name="commentRangeEnd"             type="CT_MarkupRange"/>
+        <xsd:element name="customXmlInsRangeStart"      type="CT_TrackChange"/>
+        <xsd:element name="customXmlInsRangeEnd"        type="CT_Markup"/>
+        <xsd:element name="customXmlDelRangeStart"      type="CT_TrackChange"/>
+        <xsd:element name="customXmlDelRangeEnd"        type="CT_Markup"/>
+        <xsd:element name="customXmlMoveFromRangeStart" type="CT_TrackChange"/>
+        <xsd:element name="customXmlMoveFromRangeEnd"   type="CT_Markup"/>
+        <xsd:element name="customXmlMoveToRangeStart"   type="CT_TrackChange"/>
+        <xsd:element name="customXmlMoveToRangeEnd"     type="CT_Markup"/>
+        <xsd:element name="ins"                         type="CT_RunTrackChange"/>
+        <xsd:element name="del"                         type="CT_RunTrackChange"/>
+        <xsd:element name="moveFrom"                    type="CT_RunTrackChange"/>
+        <xsd:element name="moveTo"                      type="CT_RunTrackChange"/>
+        <xsd:group   ref="EG_MathContent" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:choice>
+    </xsd:group>
+
+    <xsd:complexType name="CT_R">
+      <xsd:sequence>
+        <xsd:group ref="EG_RPr"             minOccurs="0"/>
+        <xsd:group ref="EG_RunInnerContent" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="rsidRPr" type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidDel" type="ST_LongHexNumber"/>
+      <xsd:attribute name="rsidR"   type="ST_LongHexNumber"/>
+    </xsd:complexType>
+
+    <xsd:simpleType name="ST_OnOff">
+      <xsd:union memberTypes="xsd:boolean ST_OnOff1"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="ST_OnOff1">
+      <xsd:restriction base="xsd:string">
+        <xsd:enumeration value="on"/>
+        <xsd:enumeration value="off"/>
+      </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="ST_RelationshipId">
+      <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="ST_String">
+      <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>

--- a/docs/dev/analysis/features/text/index.rst
+++ b/docs/dev/analysis/features/text/index.rst
@@ -13,3 +13,5 @@ Text
    underline
    run-content
    breaks
+   hyperlink
+

--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -38,14 +38,14 @@ class BlockItemContainer(Parented):
             paragraph.style = style
         return paragraph
 
-    def add_table(self, rows, cols, width):
+    def add_table(self, rows, cols, width, firstCol=1, firstRow=1, lastCol=0, lastRow=0, hBand=1, vBand=0):
         """
         Return a table of *width* having *rows* rows and *cols* columns,
         newly appended to the content in this container. *width* is evenly
         distributed between the table columns.
         """
         from .table import Table
-        tbl = CT_Tbl.new_tbl(rows, cols, width)
+        tbl = CT_Tbl.new_tbl(rows, cols, width, firstCol, firstRow, lastCol, lastRow, hBand, vBand)
         self._element._insert_tbl(tbl)
         return Table(tbl, self)
 

--- a/docx/document.py
+++ b/docx/document.py
@@ -89,14 +89,14 @@ class Document(ElementProxy):
         new_sectPr.start_type = start_type
         return Section(new_sectPr)
 
-    def add_table(self, rows, cols, style=None):
+    def add_table(self, rows, cols, style=None, firstCol=1, firstRow=1, lastCol=0, lastRow=0, hBand=1, vBand=0):
         """
         Add a table having row and column counts of *rows* and *cols*
         respectively and table style of *style*. *style* may be a paragraph
         style object or a paragraph style name. If *style* is |None|, the
         table inherits the default table style of the document.
         """
-        table = self._body.add_table(rows, cols, self._block_width)
+        table = self._body.add_table(rows, cols, self._block_width, firstCol, firstRow, lastCol, lastRow, hBand, vBand)
         table.style = style
         return table
 

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -129,7 +129,7 @@ register_element_cls('w:unhideWhenUsed', CT_OnOff)
 
 from .table import (
     CT_Height, CT_Row, CT_Tbl, CT_TblGrid, CT_TblGridCol, CT_TblLayoutType,
-    CT_TblPr, CT_TblWidth, CT_Tc, CT_TcPr, CT_TrPr, CT_VerticalJc, CT_VMerge
+    CT_TblPr, CT_TblWidth, CT_TblLook, CT_Tc, CT_TcPr, CT_TrPr, CT_VerticalJc, CT_VMerge
 )
 register_element_cls('w:bidiVisual', CT_OnOff)
 register_element_cls('w:gridCol',    CT_TblGridCol)
@@ -139,6 +139,7 @@ register_element_cls('w:tblGrid',    CT_TblGrid)
 register_element_cls('w:tblLayout',  CT_TblLayoutType)
 register_element_cls('w:tblPr',      CT_TblPr)
 register_element_cls('w:tblStyle',   CT_String)
+register_element_cls('w:tblLook',    CT_TblLook)
 register_element_cls('w:tc',         CT_Tc)
 register_element_cls('w:tcPr',       CT_TcPr)
 register_element_cls('w:tcW',        CT_TblWidth)

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -188,6 +188,8 @@ register_element_cls('w:p', CT_P)
 from .text.parfmt import (
     CT_Ind, CT_Jc, CT_PPr, CT_Spacing, CT_TabStop, CT_TabStops
 )
+from .text.hyperlink import CT_Hyperlink
+register_element_cls('w:hyperlink',       CT_Hyperlink)
 register_element_cls('w:ind',             CT_Ind)
 register_element_cls('w:jc',              CT_Jc)
 register_element_cls('w:keepLines',       CT_OnOff)

--- a/docx/oxml/table.py
+++ b/docx/oxml/table.py
@@ -12,7 +12,7 @@ from ..exceptions import InvalidSpanError
 from .ns import nsdecls, qn
 from ..shared import Emu, Twips
 from .simpletypes import (
-    ST_Merge, ST_TblLayoutType, ST_TblWidth, ST_TwipsMeasure, XsdInt
+    ST_Merge, ST_TblLayoutType, ST_TblWidth, ST_TwipsMeasure, XsdInt, XsdBoolean
 )
 from .xmlchemy import (
     BaseOxmlElement, OneAndOnlyOne, OneOrMore, OptionalAttribute,
@@ -150,12 +150,12 @@ class CT_Tbl(BaseOxmlElement):
                 yield tc
 
     @classmethod
-    def new_tbl(cls, rows, cols, width):
+    def new_tbl(cls, rows, cols, width, firstCol=1, firstRow=1, lastCol=0, lastRow=0, hBand=1, vBand=0):
         """
         Return a new `w:tbl` element having *rows* rows and *cols* columns
         with *width* distributed evenly between the columns.
         """
-        return parse_xml(cls._tbl_xml(rows, cols, width))
+        return parse_xml(cls._tbl_xml(rows, cols, width, firstCol, firstRow, lastCol, lastRow, hBand, vBand))
 
     @property
     def tblStyle_val(self):
@@ -181,21 +181,27 @@ class CT_Tbl(BaseOxmlElement):
         tblPr._add_tblStyle().val = styleId
 
     @classmethod
-    def _tbl_xml(cls, rows, cols, width):
+    def _tbl_xml(cls, rows, cols, width, firstCol, firstRow, lastCol, lastRow, hBand, vBand):
         col_width = Emu(width/cols) if cols > 0 else Emu(0)
         return (
             '<w:tbl %s>\n'
             '  <w:tblPr>\n'
             '    <w:tblW w:type="auto" w:w="0"/>\n'
-            '    <w:tblLook w:firstColumn="1" w:firstRow="1"\n'
-            '               w:lastColumn="0" w:lastRow="0" w:noHBand="0"\n'
-            '               w:noVBand="1" w:val="04A0"/>\n'
+            '    <w:tblLook w:firstColumn="%d" w:firstRow="%d"\n'
+            '               w:lastColumn="%d" w:lastRow="%d" w:noHBand="%d"\n'
+            '               w:noVBand="%d" w:val="04A0"/>\n'
             '  </w:tblPr>\n'
             '%s'  # tblGrid
             '%s'  # trs
             '</w:tbl>\n'
         ) % (
             nsdecls('w'),
+            firstCol,
+            firstRow,
+            lastCol,
+            lastRow,
+            0 if hBand else 1,
+            0 if vBand else 1,
             cls._tblGrid_xml(cols, col_width),
             cls._trs_xml(rows, cols, col_width)
         )
@@ -282,6 +288,7 @@ class CT_TblPr(BaseOxmlElement):
     bidiVisual = ZeroOrOne('w:bidiVisual', successors=_tag_seq[4:])
     jc = ZeroOrOne('w:jc', successors=_tag_seq[8:])
     tblLayout = ZeroOrOne('w:tblLayout', successors=_tag_seq[13:])
+    tblLook = ZeroOrOne('w:tblLook', successors=_tag_seq[15:])
     del _tag_seq
 
     @property
@@ -364,6 +371,21 @@ class CT_TblWidth(BaseOxmlElement):
     def width(self, value):
         self.type = 'dxa'
         self.w = Emu(value).twips
+
+class CT_TblLook(BaseOxmlElement):
+    """
+    Used for ``<w:tblLook>`` elements and many others, to
+    specify table-related looks.
+    """
+    # the type for `w` attr is actually ST_MeasurementOrPercent, but using
+    # XsdInt for now because only dxa (twips) values are being used. It's not
+    # entirely clear what the semantics are for other values like -01.4mm
+    firstCol = RequiredAttribute('w:firstColumn', XsdBoolean)
+    firstRow = RequiredAttribute('w:firstRow', XsdBoolean)
+    lastCol = RequiredAttribute('w:lastColumn', XsdBoolean)
+    lastRow = RequiredAttribute('w:lastRow', XsdBoolean)
+    noHBand = RequiredAttribute('w:noHBand', XsdBoolean)
+    noVBand = RequiredAttribute('w:noVBand', XsdBoolean)
 
 
 class CT_Tc(BaseOxmlElement):

--- a/docx/oxml/text/hyperlink.py
+++ b/docx/oxml/text/hyperlink.py
@@ -1,0 +1,40 @@
+# encoding: utf-8
+
+"""
+Custom element classes related to hyperlinks (CT_Hyperlink).
+"""
+
+from ..ns import qn
+from ..simpletypes import ST_String, ST_RelationshipId
+from ..xmlchemy import (
+    BaseOxmlElement, OptionalAttribute, ZeroOrMore
+)
+
+
+class CT_Hyperlink(BaseOxmlElement):
+    """
+    ``<w:hyperlink>`` element, containing the properties and text for a external hyperlink.
+    """
+    r = ZeroOrMore('w:r')
+    rid = OptionalAttribute('r:id', ST_RelationshipId)
+    anchor = OptionalAttribute('w:anchor', ST_String)
+
+    @property
+    def relationship(self):
+        """
+        String contained in ``r:id`` attribute of <w:hyperlink>. It should
+        point to a URL in the document's relationships.
+        """
+        val = self.get(qn('r:id'))
+        return val
+
+    @relationship.setter
+    def relationship(self, rId):
+        self.set(qn('r:id'), rId)
+
+    def clear_content(self):
+        """
+        Remove all child elements.
+        """
+        for child in self[:]:
+            self.remove(child)

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -14,6 +14,7 @@ class CT_P(BaseOxmlElement):
     """
     pPr = ZeroOrOne('w:pPr')
     r = ZeroOrMore('w:r')
+    hyperlink = ZeroOrMore('w:hyperlink')
 
     def _insert_pPr(self, pPr):
         self.insert(0, pPr)

--- a/docx/table.py
+++ b/docx/table.py
@@ -159,6 +159,54 @@ class Table(Parented):
         self._element.bidiVisual_val = value
 
     @property
+    def first_col(self):
+        return self._tbl.tblPr.tblLook.firstCol
+
+    @first_col.setter
+    def first_col(self, value):
+        self._tbl.tblPr.tblLook.firstCol = value
+
+    @property
+    def first_row(self):
+        return self._tbl.tblPr.tblLook.firstRow
+
+    @first_row.setter
+    def first_row(self, value):
+        self._tbl.tblPr.tblLook.firstRow = value
+
+    @property
+    def last_col(self):
+        return self._tbl.tblPr.tblLook.lastCol
+
+    @last_col.setter
+    def last_col(self, value):
+        self._tbl.tblPr.tblLook.lastCol = value
+
+    @property
+    def last_row(self):
+        return self._tbl.tblPr.tblLook.lastRow
+
+    @last_row.setter
+    def last_row(self, value):
+        self._tbl.tblPr.tblLook.lastRow = value
+
+    @property
+    def h_band(self):
+        return self._tbl.tblPr.tblLook.hBand
+
+    @h_band.setter
+    def h_band(self, value):
+        self._tbl.tblPr.tblLook.hBand = (0 if value else 1)
+
+    @property
+    def v_band(self):
+        return self._tbl.tblPr.tblLook.vBand
+
+    @v_band.setter
+    def v_band(self, value):
+        self._tbl.tblPr.tblLook.vBand = (0 if value else 1)
+
+    @property
     def _cells(self):
         """
         A sequence of |_Cell| objects, one for each cell of the layout grid.

--- a/docx/text/hyperlink.py
+++ b/docx/text/hyperlink.py
@@ -1,0 +1,60 @@
+# encoding: utf-8
+
+"""
+Hyperlink proxy objects.
+"""
+
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+from ..opc.constants import RELATIONSHIP_TYPE as RT
+from ..shared import Parented
+from .run import Run
+
+
+class Hyperlink(Parented):
+    """
+    Proxy object wrapping ``<w:hyperlink>`` element.
+    """
+    def __init__(self, hyperlink, parent):
+        super(Hyperlink, self).__init__(parent)
+        self._hyperlink = self.element = hyperlink
+
+    @property
+    def address(self):
+        rId = self._hyperlink.relationship
+        return self.part.target_ref(rId) if rId else None
+
+    @address.setter
+    def address(self, url):
+        rId = self.part.relate_to(url, RT.HYPERLINK, is_external=True)
+        self._hyperlink.relationship = rId
+
+    @property
+    def anchor(self):
+        return self._hyperlink.anchor
+
+    @anchor.setter
+    def anchor(self, anchor):
+        self._hyperlink.anchor = anchor
+
+    def iter_runs(self):
+        return [Run(r, self) for r in self._hyperlink.r_lst]
+
+    def insert_run(self, text, style=None):
+        _r = self._hyperlink.add_r()
+        run = Run(_r, self)
+        run.text = text
+        if style:
+            run.style = style
+        return run
+
+    @property
+    def text(self):
+        return ''.join([run.text for run in self.iter_runs()])
+
+    @text.setter
+    def text(self, text):
+        self._hyperlink.clear_content()
+        self.insert_run(text)

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -9,9 +9,10 @@ from __future__ import (
 )
 
 from ..enum.style import WD_STYLE_TYPE
+from ..shared import Parented
+from .hyperlink import Hyperlink
 from .parfmt import ParagraphFormat
 from .run import Run
-from ..shared import Parented
 
 
 class Paragraph(Parented):
@@ -21,6 +22,24 @@ class Paragraph(Parented):
     def __init__(self, p, parent):
         super(Paragraph, self).__init__(parent)
         self._p = self._element = p
+
+    def add_hyperlink(self, text, address=None, anchor=None, style=None):
+
+        _h = self._p.add_hyperlink()
+        _r = _h.add_r()
+        hyperlink = Hyperlink(_h, self)
+        run = Run(_r, hyperlink)
+
+        run.text = text
+        if style:
+            run.style = style
+
+        if address:
+            hyperlink.address = address
+        if anchor:
+            hyperlink.anchor = anchor
+
+        return hyperlink
 
     def add_run(self, text=None, style=None):
         """

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -77,9 +77,9 @@ class DescribeDocument(object):
         assert section is section_
 
     def it_can_add_a_table(self, add_table_fixture):
-        document, rows, cols, style, width, table_ = add_table_fixture
-        table = document.add_table(rows, cols, style)
-        document._body.add_table.assert_called_once_with(rows, cols, width)
+        document, rows, cols, style, width, firstCol, firstRow, lastCol, lastRow, hBand, vBand, table_ = add_table_fixture
+        table = document.add_table(rows, cols, style, firstCol, firstRow, lastCol, lastRow, hBand, vBand)
+        document._body.add_table.assert_called_once_with(rows, cols, width, firstCol, firstRow, lastCol, lastRow, hBand, vBand)
         assert table == table_
         assert table.style == style
 
@@ -201,9 +201,10 @@ class DescribeDocument(object):
     def add_table_fixture(self, _block_width_prop_, body_prop_, table_):
         document = Document(None, None)
         rows, cols, style = 4, 2, 'Light Shading Accent 1'
+        firstCol, firstRow, lastCol, lastRow, hBand, vBand = 1,0,1,0,1,0
         body_prop_.return_value.add_table.return_value = table_
         _block_width_prop_.return_value = width = 42
-        return document, rows, cols, style, width, table_
+        return document, rows, cols, style, width, firstCol, firstRow, lastCol, lastRow, hBand, vBand, table_
 
     @pytest.fixture
     def block_width_fixture(self, sections_prop_, section_):


### PR DESCRIPTION
I added a feature needed for another project that allow modification of table looking parameters.
It permit to set:
first/last row/col and horizontal/vertical bands values for each table at the table creation or later.

I believe that it might be useful to someone else so if you agree with that: you can merge it.