### PR TITLE
Fix linter warning for Python 3.8+ support for collections

### DIFF
--- a/docx/compat.py
+++ b/docx/compat.py
@@ -10,6 +10,11 @@ from __future__ import (
 
 import sys
 
+try:  # Python 3.8+
+    from collections import abc
+except ImportError:
+    import collections as abc
+
 # ===========================================================================
 # Python 3 versions
 # ===========================================================================

--- a/docx/section.py
+++ b/docx/section.py
@@ -4,14 +4,14 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import Sequence
+from .compat import abc
 
 from docx.blkcntnr import BlockItemContainer
 from docx.enum.section import WD_HEADER_FOOTER
 from docx.shared import lazyproperty
 
 
-class Sections(Sequence):
+class Sections(abc.Sequence):
     """Sequence of |Section| objects corresponding to the sections in the document.
 
     Supports ``len()``, iteration, and indexed access.


### PR DESCRIPTION
Fixes warning that comes up with pytest. Also fixes Python 3.8 forward compatibility.

```
.venv3/lib/python3.7/site-packages/docx/section.py:9
  DeprecationWarning: Using or importing the ABCs from 'collections'
  instead of from 'collections.abc' is deprecated, and in 3.8 it will
  stop working
      from collections import Sequence
```

See also: https://github.com/pallets/jinja/commit/31bf9b7e71c, https://github.com/python/cpython/commit/c66f9f8d