### PR TITLE
Namespaces parameter support in xpath

### DIFF
--- a/docx/oxml/xmlchemy.py
+++ b/docx/oxml/xmlchemy.py
@@ -740,13 +740,17 @@ class _OxmlElementBase(etree.ElementBase):
         """
         return serialize_for_reading(self)
 
-    def xpath(self, xpath_str):
+    def xpath(self, xpath_str, namespaces=None):
         """
         Override of ``lxml`` _Element.xpath() method to provide standard Open
         XML namespace mapping (``nsmap``) in centralized location.
+        Optional namespaces can be provided to override default namespace mapping.
         """
+        nsmap_use = nsmap.copy()
+        if namespaces is not None:
+            nsmap_use.update(namespaces)
         return super(BaseOxmlElement, self).xpath(
-            xpath_str, namespaces=nsmap
+            xpath_str, namespaces=nsmap_use
         )
 
     @property


### PR DESCRIPTION
Addition of namespaces parameter to xpath method.  Default namespace mapping is used and any namespaces that are passed in get merged into the default.  This is to allow for support of custom namespaces when necessary.

This is in reference to this issue: https://github.com/python-openxml/python-docx/issues/621