### PR TITLE
Remove all references to deprecated easy_install

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -9,26 +9,20 @@ Installing
 |docx| is hosted on PyPI, so installation is relatively simple, and just
 depends on what installation utilities you have installed.
 
-|docx| may be installed with ``pip`` if you have it available::
+|docx| may be installed with ``pip``::
 
     pip install python-docx
 
-|docx| can also be installed using ``easy_install``, although this is
-discouraged::
-
-    easy_install python-docx
-
-If neither ``pip`` nor ``easy_install`` is available, it can be installed
-manually by downloading the distribution from PyPI, unpacking the tarball,
-and running ``setup.py``::
+It can also be installed manually by downloading the distribution from PyPI,
+unpacking the tarball, and running ``setup.py``::
 
     tar xvzf python-docx-{version}.tar.gz
     cd python-docx-{version}
     python setup.py install
 
-|docx| depends on the ``lxml`` package. Both ``pip`` and ``easy_install``
-will take care of satisfying those dependencies for you, but if you use this
-last method you will need to install those yourself.
+|docx| depends on the ``lxml`` package. ``pip`` will take care of satisfying
+those dependencies for you, but if you install manually you will need to
+install it yourself.
 
 
 Dependencies


### PR DESCRIPTION
easy_install is deprecated and its use is discouraged by PyPA:

https://setuptools.readthedocs.io/en/latest/easy_install.html

> Warning: Easy Install is deprecated. Do not use it. Instead use pip.

Follow upstream advice and only recommended supported tools.