### PR TITLE
Fix deprecation warning by importing from collections.abc

### DIFF
--- a/docx/section.py
+++ b/docx/section.py
@@ -4,7 +4,11 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # Python 2.7
+    from collections import Sequence
 
 from docx.blkcntnr import BlockItemContainer
 from docx.enum.section import WD_HEADER_FOOTER


### PR DESCRIPTION
Fixes warning of the form:

    section.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
        from collections import Sequence

Fixes #619