### PR TITLE
Remove duplicate 'lxml' dependency from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ envlist = py26, py27, py34, py35, py36
 [testenv]
 deps =
     behave
-    lxml
     pyparsing
     pytest
 
@@ -29,7 +28,6 @@ commands =
 deps =
     importlib>=1.0.3
     behave
-    lxml
     mock
     pyparsing
     pytest
@@ -37,7 +35,6 @@ deps =
 [testenv:py27]
 deps =
     behave
-    lxml
     mock
     pyparsing
     pytest


### PR DESCRIPTION
tox automatically install the packages dependencies. As lxml is already
listed under install_requires in setup.py, it doesn't need to be
re-specified in tox.ini.