### PR TITLE
Prevent "invalid literal for int() with base 10" when converting

### DIFF
--- a/docx/oxml/simpletypes.py
+++ b/docx/oxml/simpletypes.py
@@ -332,7 +332,11 @@ class ST_SignedTwipsMeasure(XsdInt):
     def convert_from_xml(cls, str_value):
         if 'i' in str_value or 'm' in str_value or 'p' in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Twips(int(str_value))
+        try:
+            value = int(str_value)
+        except ValueError:
+            value = int(float(str_value))
+        return Twips(value)
 
     @classmethod
     def convert_to_xml(cls, value):
@@ -375,7 +379,11 @@ class ST_TwipsMeasure(XsdUnsignedLong):
     def convert_from_xml(cls, str_value):
         if 'i' in str_value or 'm' in str_value or 'p' in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Twips(int(str_value))
+        try:
+            value = int(str_value)
+        except ValueError:
+            value = int(float(str_value))
+        return Twips(value)
 
     @classmethod
     def convert_to_xml(cls, value):


### PR DESCRIPTION
Prevent \"invalid literal for int() with base 10\" when converting float str_value to int.