### PR TITLE
Fix tests failing on Windows due to git EOL conversion

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/test_files/** -text
+docx/templates/** -text


### PR DESCRIPTION
The tests were failing because they were performing binary comparison with
test files for which git can perform EOL (end of line) conversion. On Windows
by default this means that the '\n' are replaced by '\r\n'.

The added .gitattributes file disables the EOL conversion for the two folders
containing text files used by the tests. With this (and rechecking out the two
folders) all the tests now pass successfully on Windows.