### PR TITLE
added support for .docm files

### DIFF
--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -28,6 +28,7 @@ def part_class_selector(content_type, reltype):
 PartFactory.part_class_selector = part_class_selector
 PartFactory.part_type_for[CT.OPC_CORE_PROPERTIES] = CorePropertiesPart
 PartFactory.part_type_for[CT.WML_DOCUMENT_MAIN] = DocumentPart
+PartFactory.part_type_for[CT.WML_DOCUMENT_MACRO_ENABLED_MAIN] = DocumentPart
 PartFactory.part_type_for[CT.WML_FOOTER] = FooterPart
 PartFactory.part_type_for[CT.WML_HEADER] = HeaderPart
 PartFactory.part_type_for[CT.WML_NUMBERING] = NumberingPart

--- a/docx/api.py
+++ b/docx/api.py
@@ -23,7 +23,7 @@ def Document(docx=None):
     """
     docx = _default_docx_path() if docx is None else docx
     document_part = Package.open(docx).main_document_part
-    if document_part.content_type != CT.WML_DOCUMENT_MAIN:
+    if (document_part.content_type != CT.WML_DOCUMENT_MAIN) and (document_part.content_type != CT.WML_DOCUMENT_MACRO_ENABLED_MAIN):
         tmpl = "file '%s' is not a Word file, content type is '%s'"
         raise ValueError(tmpl % (docx, document_part.content_type))
     return document_part.document

--- a/docx/api.py
+++ b/docx/api.py
@@ -23,7 +23,7 @@ def Document(docx=None):
     """
     docx = _default_docx_path() if docx is None else docx
     document_part = Package.open(docx).main_document_part
-    if (document_part.content_type != CT.WML_DOCUMENT_MAIN) and (document_part.content_type != CT.WML_DOCUMENT_MACRO_ENABLED_MAIN):
+    if document_part.content_type not in [CT.WML_DOCUMENT_MAIN, CT.WML_DOCUMENT_MACRO_ENABLED_MAIN]:
         tmpl = "file '%s' is not a Word file, content type is '%s'"
         raise ValueError(tmpl % (docx, document_part.content_type))
     return document_part.document

--- a/docx/opc/constants.py
+++ b/docx/opc/constants.py
@@ -280,6 +280,9 @@ class CONTENT_TYPE(object):
         'application/vnd.openxmlformats-officedocument.wordprocessingml.docu'
         'ment.main+xml'
     )
+    WML_DOCUMENT_MACRO_ENABLED_MAIN = (
+        'application/vnd.ms-word.document.macroEnabled.main+xml'
+    )
     WML_ENDNOTES = (
         'application/vnd.openxmlformats-officedocument.wordprocessingml.endn'
         'otes+xml'


### PR DESCRIPTION
A long lasting issue with python-docx has been the lack of support of macro-enabled files.
A patch has been created a long time ago but I was never merged in master branch.

It is identical approach as suggested in #673.