### PR TITLE
wmf image support

### DIFF
--- a/docx/image/__init__.py
+++ b/docx/image/__init__.py
@@ -14,7 +14,7 @@ from docx.image.gif import Gif
 from docx.image.jpeg import Exif, Jfif
 from docx.image.png import Png
 from docx.image.tiff import Tiff
-
+from docx.image.wmf import Wmf
 
 SIGNATURES = (
     # class, offset, signature_bytes
@@ -26,4 +26,5 @@ SIGNATURES = (
     (Tiff, 0, b'MM\x00*'),  # big-endian (Motorola) TIFF
     (Tiff, 0, b'II*\x00'),  # little-endian (Intel) TIFF
     (Bmp,  0, b'BM'),
+    (Wmf,  0, b'\xd7\xcd\xc6\x9a\x00\x00'), # require wmf with Aldus Placeable Metafiles header
 )

--- a/docx/image/constants.py
+++ b/docx/image/constants.py
@@ -102,6 +102,7 @@ class MIME_TYPE(object):
     JPEG = 'image/jpeg'
     PNG = 'image/png'
     TIFF = 'image/tiff'
+    WMF = 'image/wmf'
 
 
 class PNG_CHUNK_TYPE(object):

--- a/docx/image/wmf.py
+++ b/docx/image/wmf.py
@@ -1,0 +1,60 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function
+
+from .constants import MIME_TYPE
+from .helpers import LITTLE_ENDIAN, StreamReader
+from .image import BaseImageHeader
+
+
+class Wmf(BaseImageHeader):
+    """
+    Image header parser for WMF images
+    """
+    @classmethod
+    def from_stream(cls, stream):
+        """
+        Return |Wmf| instance having header properties parsed from the WMF
+        image in *stream*.
+        """
+        stream_rdr = StreamReader(stream, LITTLE_ENDIAN)
+
+        # read Aldus Placeable Metafiles header fields
+        inch = stream_rdr.read_long(14)
+        x0 = stream_rdr.read_short(6)
+        y0 = stream_rdr.read_short(8)
+        x1 = stream_rdr.read_short(10)
+        y1 = stream_rdr.read_short(12)
+        
+        horz_dpi = cls._dpi()
+        vert_dpi = cls._dpi()
+
+        inch_width = (x1 - x0) / inch
+        inch_height = (y1 - y0) / inch
+
+        px_width = inch_width * horz_dpi
+        px_height = inch_height * vert_dpi
+
+        return cls(px_width, px_height, horz_dpi, vert_dpi)
+
+    @property
+    def content_type(self):
+        """
+        MIME content type for this image, unconditionally `image/wmf` for
+        WMF images.
+        """
+        return MIME_TYPE.WMF
+
+    @property
+    def default_ext(self):
+        """
+        Default filename extension, always 'wmf' for WMF images.
+        """
+        return 'wmf'
+
+    @staticmethod
+    def _dpi():
+        """
+        Defaulting to 96 pixels per inch
+        """
+        return 96


### PR DESCRIPTION
I'm trying to use some sort of vector graphics format inside docx and wmf seemed the easiest candidate. This is a very basic support for the most common variety of wmf files.