### PR TITLE
Add 'zip_safe' == False to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ CLASSIFIERS = [
 
 LONG_DESCRIPTION = text_of('README.rst') + '\n\n' + text_of('HISTORY.rst')
 
+ZIP_SAFE = False
 
 params = {
     'name':             NAME,
@@ -77,6 +78,7 @@ params = {
     'tests_require':    TESTS_REQUIRE,
     'test_suite':       TEST_SUITE,
     'classifiers':      CLASSIFIERS,
+    'zip_safe':         ZIP_SAFE,
 }
 
 setup(**params)


### PR DESCRIPTION
If `python-docx` is used as an `install_requires` dependency of another package, it will be installed as a zipped egg by default. At runtime, this will result in a `docx.opc.exceptions.PackageNotFoundError` exception when creating a new document. This change ensures the egg is installed unzipped. Full stack trace below from a private project:

```
Traceback (most recent call last):
  File "/usr/local/bin/[redacted]", line 4, in <module>
    __import__('pkg_resources').run_script('[redacted]==0.1', '[redacted]')
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1469, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.6/site-packages/[redacted]-0.1-py3.6.egg/EGG-INFO/scripts/[redacted]", line 4, in <module>
    __import__('pkg_resources').run_script('[redacted]==0.1', '[redacted]')
  File "/usr/local/lib/python3.6/site-packages/[redacted]-0.1-py3.6.egg/[redacted].py", line 246, in [redacted]
  File "/usr/local/lib/python3.6/site-packages/python_docx-0.8.10-py3.6.egg/docx/api.py", line 25, in Document
  File "/usr/local/lib/python3.6/site-packages/python_docx-0.8.10-py3.6.egg/docx/opc/package.py", line 128, in open
  File "/usr/local/lib/python3.6/site-packages/python_docx-0.8.10-py3.6.egg/docx/opc/pkgreader.py", line 32, in from_file
  File "/usr/local/lib/python3.6/site-packages/python_docx-0.8.10-py3.6.egg/docx/opc/phys_pkg.py", line 31, in __new__
docx.opc.exceptions.PackageNotFoundError: Package not found at '/usr/local/lib/python3.6/site-packages/python_docx-0.8.10-py3.6.egg/docx/templates/default.docx'
```