### PR TITLE
Feature: Section.paragraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 _scratch/
 Session.vim
 /.tox/
+.idea

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -61,6 +61,15 @@ class CT_P(BaseOxmlElement):
         pPr._remove_sectPr()
         pPr._insert_sectPr(sectPr)
 
+    def has_sectPr(self):
+        """
+        If has <w:sectPr>, return True, else return False
+        """
+        pPr = self.pPr
+        if pPr is None:
+            return False
+        return pPr.sectPr is not None
+
     @property
     def style(self):
         """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -136,6 +136,12 @@ class Paragraph(Parented):
         self.clear()
         self.add_run(text)
 
+    def is_section_break(self):
+        """
+        Is this paragraph a section break
+        """
+        return self._p.has_sectPr()
+
     def _insert_paragraph_before(self):
         """
         Return a newly created paragraph, inserted directly before this

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -75,6 +75,15 @@ class DescribeSections(object):
         ]
         assert section_lst == [section_, section_]
 
+    def it_knows_how_many_paragraphs_in_each_section(self):
+        document_elm = element(
+            "w:document/w:body/(w:p,w:p,w:p/w:pPr/w:sectPr,w:p/w:pPr/w:sectPr,w:p,w:sectPr)"
+        )
+        sections = Sections(document_elm, None)
+        expected = [3, 1, 1]
+        for i, section in enumerate(sections):
+            assert len(section.paragraphs) == expected[i]
+
     # fixture components ---------------------------------------------
 
     @pytest.fixture


### PR DESCRIPTION
For issue #181

Support access paragraphs in a `Section` by `paragraphs`， For example:

```python
from docx import Document
d = Document("a.xml")
d.sections[0].paragraphs
``` 