### PR TITLE
eastAsia fonts settings

### DIFF
--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -32,6 +32,7 @@ class CT_Fonts(BaseOxmlElement):
     """
     ascii = OptionalAttribute('w:ascii', ST_String)
     hAnsi = OptionalAttribute('w:hAnsi', ST_String)
+    eastAsia = OptionalAttribute('w:eastAsia', ST_String)
 
 
 class CT_Highlight(BaseOxmlElement):
@@ -137,6 +138,27 @@ class CT_RPr(BaseOxmlElement):
             return
         rFonts = self.get_or_add_rFonts()
         rFonts.ascii = value
+
+    @property
+    def rFonts_eastAsia(self):
+        """
+        The value of `w:rFonts/@w:eastAsia` or |None| if not present. Represents
+        the assigned typeface name. The rFonts element also specifies other
+        special-case typeface names; this method handles the case where just
+        the common name is required.
+        """
+        rFonts = self.rFonts
+        if rFonts is None:
+            return None
+        return rFonts.eastAsia
+
+    @rFonts_eastAsia.setter
+    def rFonts_eastAsia(self, value):
+        if value is None:
+            self._remove_rFonts()
+            return
+        rFonts = self.get_or_add_rFonts()
+        rFonts.eastAsia = value
 
     @property
     def rFonts_hAnsi(self):

--- a/docx/text/font.py
+++ b/docx/text/font.py
@@ -196,6 +196,7 @@ class Font(ElementProxy):
         rPr = self._element.get_or_add_rPr()
         rPr.rFonts_ascii = value
         rPr.rFonts_hAnsi = value
+        rPr.rFonts_eastAsia = value
 
     @property
     def no_proof(self):

--- a/tests/text/test_font.py
+++ b/tests/text/test_font.py
@@ -227,13 +227,13 @@ class DescribeFont(object):
 
     @pytest.fixture(params=[
         ('w:r',                                          'Foo',
-         'w:r/w:rPr/w:rFonts{w:ascii=Foo,w:hAnsi=Foo}'),
+         'w:r/w:rPr/w:rFonts{w:ascii=Foo,w:hAnsi=Foo,w:eastAsia=Foo}'),
         ('w:r/w:rPr',                                    'Foo',
-         'w:r/w:rPr/w:rFonts{w:ascii=Foo,w:hAnsi=Foo}'),
+         'w:r/w:rPr/w:rFonts{w:ascii=Foo,w:hAnsi=Foo,w:eastAsia=Foo}'),
         ('w:r/w:rPr/w:rFonts{w:hAnsi=Foo}',              'Bar',
-         'w:r/w:rPr/w:rFonts{w:ascii=Bar,w:hAnsi=Bar}'),
+         'w:r/w:rPr/w:rFonts{w:ascii=Bar,w:hAnsi=Bar,w:eastAsia=Bar}'),
         ('w:r/w:rPr/w:rFonts{w:ascii=Foo,w:hAnsi=Foo}',  'Bar',
-         'w:r/w:rPr/w:rFonts{w:ascii=Bar,w:hAnsi=Bar}'),
+         'w:r/w:rPr/w:rFonts{w:ascii=Bar,w:hAnsi=Bar,w:eastAsia=Bar}'),
     ])
     def name_set_fixture(self, request):
         r_cxml, value, expected_r_cxml = request.param


### PR DESCRIPTION
In [PR #329](https://github.com/python-openxml/python-docx/pull/329), the author added the `eastAsia` property [without updating the unit test](https://travis-ci.org/python-openxml/python-docx/builds/170694988). This PR updates the unit test code.