### PR TITLE
Some hack to include SVG

### DIFF
--- a/docx/image/__init__.py
+++ b/docx/image/__init__.py
@@ -14,7 +14,7 @@ from docx.image.gif import Gif
 from docx.image.jpeg import Exif, Jfif
 from docx.image.png import Png
 from docx.image.tiff import Tiff
-
+from docx.image.svg import Svg
 
 SIGNATURES = (
     # class, offset, signature_bytes
@@ -26,4 +26,5 @@ SIGNATURES = (
     (Tiff, 0, b'MM\x00*'),  # big-endian (Motorola) TIFF
     (Tiff, 0, b'II*\x00'),  # little-endian (Intel) TIFF
     (Bmp,  0, b'BM'),
+    (Svg, 2, b'xml'),
 )

--- a/docx/image/constants.py
+++ b/docx/image/constants.py
@@ -102,6 +102,7 @@ class MIME_TYPE(object):
     JPEG = 'image/jpeg'
     PNG = 'image/png'
     TIFF = 'image/tiff'
+    SVG = 'image/svg'
 
 
 class PNG_CHUNK_TYPE(object):

--- a/docx/image/svg.py
+++ b/docx/image/svg.py
@@ -1,0 +1,48 @@
+# encoding: utf-8
+
+from __future__ import absolute_import, division, print_function
+
+from struct import Struct
+
+from .constants import MIME_TYPE
+from .image import BaseImageHeader
+
+
+class Svg(BaseImageHeader):
+    """
+    Image header parser for GIF images. Note that the GIF format does not
+    support resolution (DPI) information. Both horizontal and vertical DPI
+    default to 72.
+    """
+    @classmethod
+    def from_stream(cls, stream):
+        """
+        Return |Gif| instance having header properties parsed from GIF image
+        in *stream*.
+        """
+        px_width, px_height = cls._dimensions_from_stream(stream)
+        return cls(px_width, px_height, 72, 72)
+
+    @property
+    def content_type(self):
+        """
+        MIME content type for this image, unconditionally `image/svg` for
+        SVG images.
+        """
+        return MIME_TYPE.SVG
+
+    @property
+    def default_ext(self):
+        """
+        Default filename extension, always 'gif' for GIF images.
+        """
+        return 'svg'
+
+    @classmethod
+    def _dimensions_from_stream(cls, stream):
+        from xml.etree import ElementTree
+        stream.seek(0)
+        text = stream.read()
+        root = ElementTree.fromstring(text)
+        x_min, y_min, x_max, y_max = [float(coord) for coord in root.attrib['viewBox'].split()]
+        return x_max - x_min, y_max - y_min

--- a/docx/opc/pkgwriter.py
+++ b/docx/opc/pkgwriter.py
@@ -50,7 +50,13 @@ class PackageWriter(object):
         Write the blob of each part in *parts* to the package, along with a
         rels item for its relationships if and only if it has any.
         """
+        from docx.parts.image import ImagePart
         for part in parts:
+            if isinstance(part, ImagePart):
+                if part.partname.endswith('.svg'):
+                    part.load_rel("http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+                                  part,
+                                  'rId0')
             phys_writer.write(part.partname, part.blob)
             if len(part._rels):
                 phys_writer.write(part.partname.rels_uri, part._rels.xml)

--- a/tests/image/test_svg.py
+++ b/tests/image/test_svg.py
@@ -1,0 +1,92 @@
+# encoding: utf-8
+
+"""Unit test suite for docx.image.svg module"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from docx.compat import BytesIO
+from docx.image.constants import MIME_TYPE
+from docx.image.svg import Svg
+
+from ..unitutil.mock import ANY, initializer_mock
+
+
+class DescribeSvg(object):
+
+    def it_can_construct_from_a_svg_stream(self, Svg__init__):
+        cx, cy = 81.56884, 17.054602
+        bytes_ = b"""\
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg883"
+   version="1.1"
+   viewBox="0 0 81.56884 17.054602"
+   height="17.054602mm"
+   width="81.56884mm">
+  <defs
+     id="defs877" />
+  <metadata
+     id="metadata880">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(238.27068,33.733892)"
+     id="layer1">
+    <text
+       id="text843"
+       y="-16.976948"
+       x="-238.27068"
+       style="font-style:normal;font-weight:normal;font-size:22.57777786px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.26458332"
+         y="-16.976948"
+         x="-238.27068"
+         id="tspan841">Test 2 !</tspan></text>
+    <flowRoot
+       transform="matrix(0.26458333,0,0,0.26458333,-238.27068,-33.392139)"
+       style="font-style:normal;font-weight:normal;font-size:85.33333588px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       id="flowRoot814"
+       xml:space="preserve"><flowRegion
+         id="flowRegion816"><rect
+           y="-63.976192"
+           x="-182.85715"
+           height="248.57143"
+           width="880"
+           id="rect818" /></flowRegion><flowPara
+         id="flowPara820" /></flowRoot>  </g>
+</svg>"""
+        stream = BytesIO(bytes_)
+
+        svg = Svg.from_stream(stream)
+
+        Svg__init__.assert_called_once_with(ANY, cx, cy, 72, 72)
+        assert isinstance(svg, Svg)
+
+    def it_knows_its_content_type(self):
+        svg = Svg(None, None, None, None)
+        assert svg.content_type == MIME_TYPE.SVG
+
+    def it_knows_its_default_ext(self):
+        svg = Svg(None, None, None, None)
+        assert svg.default_ext == 'svg'
+
+    # fixture components ---------------------------------------------
+
+    @pytest.fixture
+    def Svg__init__(self, request):
+        return initializer_mock(request, Svg)


### PR DESCRIPTION
`shape.py` and `pkgwriter.py` are particularly ugly but it works with Word for Office 365 (16.0)