### PR TITLE
Modification to enable producing consistent binary output for the same data

### DIFF
--- a/docx/opc/phys_pkg.py
+++ b/docx/opc/phys_pkg.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 import os
 
-from zipfile import ZipFile, is_zipfile, ZIP_DEFLATED
+from zipfile import ZipFile, ZipInfo, is_zipfile, ZIP_DEFLATED
 
 from .compat import is_string
 from .exceptions import PackageNotFoundError
@@ -152,4 +152,5 @@ class _ZipPkgWriter(PhysPkgWriter):
         Write *blob* to this zip package with the membername corresponding to
         *pack_uri*.
         """
-        self._zipf.writestr(pack_uri.membername, blob)
+        zinfo = ZipInfo(filename=pack_uri.membername, date_time=(1980, 1, 1, 0, 0, 0))
+        self._zipf.writestr(zinfo, blob)

--- a/docx/opc/pkgwriter.py
+++ b/docx/opc/pkgwriter.py
@@ -30,9 +30,10 @@ class PackageWriter(object):
         content types of the parts.
         """
         phys_writer = PhysPkgWriter(pkg_file)
-        PackageWriter._write_content_types_stream(phys_writer, parts)
+        sorted_parts = sorted(parts, key=lambda p: p.partname)
+        PackageWriter._write_content_types_stream(phys_writer, sorted_parts)
         PackageWriter._write_pkg_rels(phys_writer, pkg_rels)
-        PackageWriter._write_parts(phys_writer, parts)
+        PackageWriter._write_parts(phys_writer, sorted_parts)
         phys_writer.close()
 
     @staticmethod

--- a/docx/opc/rel.py
+++ b/docx/opc/rel.py
@@ -78,7 +78,7 @@ class Relationships(dict):
         as a .rels file in an OPC package.
         """
         rels_elm = CT_Relationships.new()
-        for rel in self.values():
+        for rel in sorted(self.values(), key=lambda r: r._rId):
             rels_elm.add_rel(
                 rel.rId, rel.reltype, rel.target_ref, rel.is_external
             )


### PR DESCRIPTION
Three elements were needed:
- modification timestamps for files being zipped have to be set explicitly to  1980-01-01 (as MS Word does) not defaulting to current time,
- relationship infos have to be sorted to make xml stable,
- docx parts have to be sorted to make file order in zip stable

For my documents that's all that was needed to keep binary output stable. I hope it helps!