### PR TITLE
fix: #609 support for python 2.6

### DIFF
--- a/docx/opc/package.py
+++ b/docx/opc/package.py
@@ -113,7 +113,10 @@ class OpcPackage(object):
         containing a single replacement item, a '%d' to be used to insert the integer
         portion of the partname. Example: "/word/header%d.xml"
         """
-        partnames = {part.partname for part in self.iter_parts()}
+        partnames = {}
+        for part in self.iter_parts():
+            partnames.append(part.partname)
+
         for n in range(1, len(partnames) + 2):
             candidate_partname = template % n
             if candidate_partname not in partnames:


### PR DESCRIPTION
Backtrace of the issue:
    from docx import Document
    Traceback (most recent call last):
    File , line 1, in
    File /usr/lib/python2.6/site-packages/docx/init.py, line 3, in
    from docx.api import Document # noqa
    File /usr/lib/python2.6/site-packages/docx/api.py, line 14, in
    from docx.package import Package
    File /usr/lib/python2.6/site-packages/docx/package.py, line 9, in
    from docx.opc.package import OpcPackage
    File /usr/lib/python2.6/site-packages/docx/opc/package.py, line 116
    partnames = {part.partname for part in self.iter_parts()}
    ^
    SyntaxError: invalid syntax