### PR TITLE
Include hyperlink text in paragraph.text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 _scratch/
 Session.vim
 /.tox/
+venv
+.vscode

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -192,7 +192,10 @@ register_element_cls('w:pStyle',          CT_String)
 register_element_cls('w:spacing',         CT_Spacing)
 register_element_cls('w:widowControl',    CT_OnOff)
 
-from .text.run import CT_Br, CT_R, CT_Text
+from .text.hyperlink import CT_Hyperlink
+register_element_cls('w:hyperlink',  CT_Hyperlink)
+
+from .text.run import CT_Br, CT_R, CT_Text 
 register_element_cls('w:br', CT_Br)
 register_element_cls('w:r',  CT_R)
 register_element_cls('w:t',  CT_Text)

--- a/docx/oxml/text/hyperlink.py
+++ b/docx/oxml/text/hyperlink.py
@@ -1,0 +1,25 @@
+
+"""
+Custom element classes related to hyperlinks (CT_Hyperlink).
+"""
+
+from ..ns import qn
+from ..xmlchemy import BaseOxmlElement, OxmlElement, ZeroOrMore 
+
+class CT_Hyperlink(BaseOxmlElement):
+    """
+    ``<w:hyperlink>`` element, containing the properties and text for a hyperlink.
+    """
+    r = ZeroOrMore('w:r')
+
+    def clear_content(self):
+        """
+        Remove all child elements
+        """
+        for child in self[:]:
+            self.remove(child)
+
+
+
+
+

--- a/docx/oxml/text/paragraph.py
+++ b/docx/oxml/text/paragraph.py
@@ -76,3 +76,13 @@ class CT_P(BaseOxmlElement):
     def style(self, style):
         pPr = self.get_or_add_pPr()
         pPr.style = style
+    
+    @property
+    def inline_items(self):
+        return self.xpath('./w:r | ./w:hyperlink')
+
+    inline_items.__doc__ = (
+        'A list containing each of the ``<w:r> | <w:hyperlink>`` child elements, in the o'
+        'rder they appear.'
+    )
+

--- a/docx/runcntnr.py
+++ b/docx/runcntnr.py
@@ -1,0 +1,63 @@
+"""
+Run item container, used by paragraph, hyperlink.
+"""
+
+from __future__ import absolute_import, print_function
+
+from .shared import Parented
+from .text.run import Run
+
+
+class RunItemContainer(Parented):
+    def __init__(self, element, parent):
+        super(RunItemContainer, self).__init__(parent)
+        self._element = element
+
+    def add_run(self, text=None, style=None):
+        """
+        Append a run to this container containing *text* and having character
+        style identified by style ID *style*. *text* can contain tab
+        (``\\t``) characters, which are converted to the appropriate XML form
+        for a tab. *text* can also include newline (``\\n``) or carriage
+        return (``\\r``) characters, each of which is converted to a line
+        break.
+        """
+        r = self._element.add_r()
+        run = Run(r, self)
+        if text:
+            run.text = text
+        if style:
+            run.style = style
+        return run
+
+    @property
+    def runs(self):
+        """
+        Sequence of |Run| instances corresponding to the <w:r> elements in
+        this container.
+        """
+        return [Run(r, self) for r in self._element.r_lst]
+
+    @property
+    def text(self):
+        """
+        String formed by concatenating the text of each run in the paragraph.
+        Tabs and line breaks in the XML are mapped to ``\\t`` and ``\\n``
+        characters respectively.
+
+        Assigning text to this property causes all existing paragraph content
+        to be replaced with a single run containing the assigned text.
+        A ``\\t`` character in the text is mapped to a ``<w:tab/>`` element
+        and each ``\\n`` or ``\\r`` character is mapped to a line break.
+        Paragraph-level formatting, such as style, is preserved. All
+        run-level formatting, such as bold or italic, is removed.
+        """
+        text = ''
+        for run in self.runs:
+            text += run.text
+        return text
+
+    @text.setter
+    def text(self, text):
+        self.clear()
+        self.add_run(text)

--- a/docx/text/hyperlink.py
+++ b/docx/text/hyperlink.py
@@ -1,0 +1,32 @@
+
+"""
+Hyperlink-related proxy types.
+"""
+
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+from .run import Run
+from ..shared import Parented
+from ..runcntnr import RunItemContainer
+
+class Hyperlink(RunItemContainer):
+    """
+    Proxy object wrapping ``<w:hyperlink>`` element.
+    """
+    def __init__(self, h, parent):
+        super(Hyperlink, self).__init__(h, parent)
+        self._h = self._element = h
+
+    def clear(self):
+        """
+        Return this same paragraph after removing all its content.
+        Paragraph-level formatting, such as style, is preserved.
+        """
+        self._h.clear_content()
+        return self
+
+    @property
+    def runs(self):
+        return super(Hyperlink, self).runs


### PR DESCRIPTION
Included hyperlink text in `paragraph.text`, added new property `inline_items` in `paragraph` to iterate both `run` and `hyperlink` in paragraph.