### PR TITLE
Do not list sectPr elements as part of sectPrChange as sections of the document

### DIFF
--- a/docx/oxml/document.py
+++ b/docx/oxml/document.py
@@ -20,7 +20,7 @@ class CT_Document(BaseOxmlElement):
         Return a list containing a reference to each ``<w:sectPr>`` element
         in the document, in the order encountered.
         """
-        return self.xpath('.//w:sectPr')
+        return self.xpath('.//w:sectPr[not(ancestor::w:sectPrChange)]')
 
 
 class CT_Body(BaseOxmlElement):


### PR DESCRIPTION
So, SectPr elements are listed in document.xml as either part of a paragraph or as part of the body.[1] However, a SectPr element can also contain SectPrChange, which in turn contains a SectPr [2].

This happens in my document:

```
      <w:pPr>
        <w:sectPr w:rsidR="00122A98" w:rsidRPr="00D92F4F" w:rsidSect="004B04EA">
          <w:headerReference w:type="default" r:id="rId8"/>
          <w:footerReference w:type="even" r:id="rId9"/>
          <w:footerReference w:type="default" r:id="rId10"/>
          <w:pgSz w:w="11906" w:h="16838"/>
          <w:pgMar w:top="1758" w:right="1440" w:bottom="1134" w:left="1729" w:header="1440" w:footer="0" w:gutter="0"/>
          <w:cols w:space="720"/>
          <w:formProt w:val="0"/>
          <w:docGrid w:linePitch="360" w:charSpace="8192"/>
          <w:sectPrChange w:id="0" w:author="Edwin Smulders" w:date="2020-09-04T14:36:00Z">
            <w:sectPr w:rsidR="00122A98" w:rsidRPr="00D92F4F" w:rsidSect="004B04EA">
              <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="709" w:footer="709" w:gutter="0"/>
            </w:sectPr>
          </w:sectPrChange>
        </w:sectPr>
      </w:pPr>
```

The `sectPr_lst` will show 2 sections for these elements, although it is only one section.
This MR fixes this.


[1] http://officeopenxml.com/WPsection.php
[2] http://www.datypic.com/sc/ooxml/e-w_sectPr-2.html