### PR TITLE
Add support for RGBColor font highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 _scratch/
 Session.vim
 /.tox/
+.venv/
+venv/

--- a/docx/enum/base.py
+++ b/docx/enum/base.py
@@ -287,6 +287,10 @@ class EnumValue(int):
         self._docstring = docstring
 
     @property
+    def name(self):
+        return self._member_name
+
+    @property
     def __doc__(self):
         """
         The description of this enumeration member

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -185,6 +185,7 @@ from .text.font import (  # noqa
     CT_Color,
     CT_Fonts,
     CT_Highlight,
+    CT_Shd,
     CT_HpsMeasure,
     CT_RPr,
     CT_Underline,
@@ -198,6 +199,7 @@ register_element_cls('w:cs',         CT_OnOff)
 register_element_cls('w:dstrike',    CT_OnOff)
 register_element_cls('w:emboss',     CT_OnOff)
 register_element_cls('w:highlight',  CT_Highlight)
+register_element_cls('w:shd',        CT_Shd)
 register_element_cls('w:i',          CT_OnOff)
 register_element_cls('w:iCs',        CT_OnOff)
 register_element_cls('w:imprint',    CT_OnOff)

--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -14,6 +14,7 @@ from ..simpletypes import (
 from ..xmlchemy import (
     BaseOxmlElement, OptionalAttribute, RequiredAttribute, ZeroOrOne
 )
+from ...shared import RGBColor
 
 
 class CT_Color(BaseOxmlElement):
@@ -39,6 +40,13 @@ class CT_Highlight(BaseOxmlElement):
     `w:highlight` element, specifying font highlighting/background color.
     """
     val = RequiredAttribute('w:val', WD_COLOR)
+
+
+class CT_Shd(BaseOxmlElement):
+    """
+    `w:shd` element, specifying font highlighting/background color.
+    """
+    fill = RequiredAttribute('w:fill', ST_HexColor)
 
 
 class CT_HpsMeasure(BaseOxmlElement):
@@ -83,6 +91,7 @@ class CT_RPr(BaseOxmlElement):
     color = ZeroOrOne('w:color', successors=_tag_seq[19:])
     sz = ZeroOrOne('w:sz', successors=_tag_seq[24:])
     highlight = ZeroOrOne('w:highlight', successors=_tag_seq[26:])
+    shd = ZeroOrOne('w:shd', successors=_tag_seq[26:])
     u = ZeroOrOne('w:u', successors=_tag_seq[27:])
     vertAlign = ZeroOrOne('w:vertAlign', successors=_tag_seq[32:])
     rtl = ZeroOrOne('w:rtl', successors=_tag_seq[33:])
@@ -111,11 +120,36 @@ class CT_RPr(BaseOxmlElement):
 
     @highlight_val.setter
     def highlight_val(self, value):
+        self._remove_shd()
         if value is None:
             self._remove_highlight()
             return
         highlight = self.get_or_add_highlight()
         highlight.val = value
+
+    @property
+    def shd_fill(self):
+        """
+        Value of `w:shd/@fill` attribute, specifying a font's highlight
+        color, or `None` if the text is not highlighted.
+        """
+        shd = self.shd
+        if shd is None:
+            return None
+        return shd.fill
+
+    @shd_fill.setter
+    def shd_fill(self, fill):
+        self._remove_highlight()
+        if fill is None:
+            self._remove_shd()
+            return
+
+        if isinstance(fill, str):
+            fill = RGBColor.from_string(fill)
+
+        shd = self.get_or_add_shd()
+        shd.fill = fill
 
     @property
     def rFonts_ascii(self):

--- a/docx/oxml/xmlchemy.py
+++ b/docx/oxml/xmlchemy.py
@@ -613,7 +613,7 @@ class ZeroOrOne(_BaseChildElement):
 
 class ZeroOrOneChoice(_BaseChildElement):
     """
-    Correspondes to an ``EG_*`` element group where at most one of its
+    Corresponds to an ``EG_*`` element group where at most one of its
     members may appear as a child.
     """
     def __init__(self, choices, successors=()):

--- a/docx/shared.py
+++ b/docx/shared.py
@@ -149,6 +149,7 @@ class RGBColor(tuple):
         """
         Return a new instance from an RGB color hex string like ``'3C2F80'``.
         """
+        rgb_hex_str = rgb_hex_str.replace('#', '')
         r = int(rgb_hex_str[:2], 16)
         g = int(rgb_hex_str[2:4], 16)
         b = int(rgb_hex_str[4:], 16)

--- a/docx/text/font.py
+++ b/docx/text/font.py
@@ -9,6 +9,7 @@ from __future__ import (
 )
 
 from ..dml.color import ColorFormat
+from ..enum.text import WD_COLOR_INDEX
 from ..shared import ElementProxy
 
 
@@ -134,12 +135,20 @@ class Font(ElementProxy):
         rPr = self._element.rPr
         if rPr is None:
             return None
-        return rPr.highlight_val
+
+        highlight = rPr.highlight_val
+        if highlight is not None:
+            return highlight
+
+        return rPr.shd_fill
 
     @highlight_color.setter
     def highlight_color(self, value):
         rPr = self._element.get_or_add_rPr()
-        rPr.highlight_val = value
+        if not isinstance(value, str) and getattr(WD_COLOR_INDEX, value.name, None) is not None:
+            rPr.highlight_val = value
+        else:
+            rPr.shd_fill = value
 
     @property
     def italic(self):

--- a/tests/text/test_font.py
+++ b/tests/text/test_font.py
@@ -10,7 +10,7 @@ from __future__ import (
 
 from docx.dml.color import ColorFormat
 from docx.enum.text import WD_COLOR, WD_UNDERLINE
-from docx.shared import Pt
+from docx.shared import Pt, RGBColor
 from docx.text.font import Font
 
 import pytest
@@ -188,6 +188,7 @@ class DescribeFont(object):
         ('w:r/w:rPr',                            None),
         ('w:r/w:rPr/w:highlight{w:val=default}', WD_COLOR.AUTO),
         ('w:r/w:rPr/w:highlight{w:val=blue}',    WD_COLOR.BLUE),
+        ('w:r/w:rPr/w:shd{w:fill=6195ED}',       RGBColor.from_string('6195ED')),
     ])
     def highlight_get_fixture(self, request):
         r_cxml, expected_value = request.param
@@ -201,7 +202,9 @@ class DescribeFont(object):
          'w:r/w:rPr/w:highlight{w:val=green}'),
         ('w:r/w:rPr/w:highlight{w:val=green}',  WD_COLOR.YELLOW,
          'w:r/w:rPr/w:highlight{w:val=yellow}'),
-        ('w:r/w:rPr/w:highlight{w:val=yellow}', None,
+        ('w:r/w:rPr/w:highlight{w:val=yellow}', RGBColor.from_string('6195ED'),
+         'w:r/w:rPr/w:shd{w:fill=6195ED}'),
+        ('w:r/w:rPr/w:shd{w:fill=6195ED}',      None,
          'w:r/w:rPr'),
         ('w:r/w:rPr',                           None,
          'w:r/w:rPr'),


### PR DESCRIPTION
* Define `w:shd` empirically (based on `w:highlight`)
  So far, `w:shd` and `w:highlight` appear to be the same attributes
  for different values (`RGBColor` vs `WS_COLOR_INDEX`)
* Add `{,.}venv` on `.gitignore`
* Add `EnumValue.name` attribute, to be able to retrieve an attribute's name
* Fix a typo

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>