### PR TITLE
Fix "KeyError: no style with name 'Heading 1'" when using a file edit…

### DIFF
--- a/docx/styles/styles.py
+++ b/docx/styles/styles.py
@@ -41,6 +41,10 @@ class Styles(ElementProxy):
         if style_elm is not None:
             return StyleFactory(style_elm)
 
+        style_elm = self._element.get_by_name(key)
+        if style_elm is not None:
+            return StyleFactory(style_elm)
+
         style_elm = self._element.get_by_id(key)
         if style_elm is not None:
             msg = (


### PR DESCRIPTION
…ed with Libre Office.

This error happens due to the style "Heading 1" being capitalized in the docx xml, unlike MS Word does.