### PR TITLE
Fixing tests on Windows

### DIFF
--- a/tests/opc/test_phys_pkg.py
+++ b/tests/opc/test_phys_pkg.py
@@ -43,17 +43,17 @@ class DescribeDirPkgReader(object):
 
     def it_can_retrieve_the_blob_for_a_pack_uri(self, dir_reader):
         pack_uri = PackURI('/word/document.xml')
-        blob = dir_reader.blob_for(pack_uri)
+        blob = dir_reader.blob_for(pack_uri).replace(b'\r\n', b'\n')
         sha1 = hashlib.sha1(blob).hexdigest()
         assert sha1 == '0e62d87ea74ea2b8088fd11ee97b42da9b4c77b0'
 
     def it_can_get_the_content_types_xml(self, dir_reader):
-        sha1 = hashlib.sha1(dir_reader.content_types_xml).hexdigest()
+        sha1 = hashlib.sha1(dir_reader.content_types_xml.replace(b'\r\n', b'\n')).hexdigest()
         assert sha1 == '89aadbb12882dd3d7340cd47382dc2c73d75dd81'
 
     def it_can_retrieve_the_rels_xml_for_a_source_uri(self, dir_reader):
         rels_xml = dir_reader.rels_xml_for(PACKAGE_URI)
-        sha1 = hashlib.sha1(rels_xml).hexdigest()
+        sha1 = hashlib.sha1(rels_xml.replace(b'\r\n', b'\n')).hexdigest()
         assert sha1 == 'ebacdddb3e7843fdd54c2f00bc831551b26ac823'
 
     def it_returns_none_when_part_has_no_rels_xml(self, dir_reader):

--- a/tests/parts/test_hdrftr.py
+++ b/tests/parts/test_hdrftr.py
@@ -50,7 +50,7 @@ class DescribeFooterPart(object):
 
     def it_loads_default_footer_XML_from_a_template_to_help(self):
         # ---tests integration with OS---
-        xml_bytes = FooterPart._default_footer_xml()
+        xml_bytes = FooterPart._default_footer_xml().replace(b'\r\n', b'\n')
 
         assert xml_bytes.startswith(
             b"<?xml version='1.0' encoding='UTF-8' standalone='yes'?>\n<w:ftr\n"
@@ -119,7 +119,7 @@ class DescribeHeaderPart(object):
 
     def it_loads_default_header_XML_from_a_template_to_help(self):
         # ---tests integration with OS---
-        xml_bytes = HeaderPart._default_header_xml()
+        xml_bytes = HeaderPart._default_header_xml().replace(b'\r\n', b'\n')
 
         assert xml_bytes.startswith(
             b"<?xml version='1.0' encoding='UTF-8' standalone='yes'?>\n<w:hdr\n"

--- a/tests/unitutil/file.py
+++ b/tests/unitutil/file.py
@@ -36,6 +36,7 @@ def snippet_seq(name, offset=0, count=1024):
     path = os.path.join(test_file_dir, 'snippets', '%s.txt' % name)
     with open(path, 'rb') as f:
         text = f.read().decode('utf-8')
+        text = text.replace('\r\n', '\n')
     snippets = text.split('\n\n')
     start, end = offset, offset+count
     return tuple(snippets[start:end])


### PR DESCRIPTION
Tests currently fail on Windows (see attached logs) depending on git's auto line ending settings. 

The tests that fail are ones that read from test files that contain WIndows line endings (`\r\n`) and then compare the output against a pre-computed expected hash. Those hashes are computed against Unix line-ending versions (presumably, whoever author and runs these tests are using Unix line endings and has git configured to auto line-endings).

Fixed locally in test cases and test utils by normalizing endings before comparisons. I focused the changes to the test cases and utils (instead of actual code) because I don't think the code should be changing line endings in the background. 

[windows.log](https://github.com/python-openxml/python-docx/files/8918491/windows.log)
