### PR TITLE
Improving Paragraph.text performance by 500%~

### DIFF
--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -126,10 +126,9 @@ class Paragraph(Parented):
         Paragraph-level formatting, such as style, is preserved. All
         run-level formatting, such as bold or italic, is removed.
         """
-        text = ''
-        for run in self.runs:
-            text += run.text
-        return text
+        if not self.runs:
+            return ''
+        return ''.join([run.text for run in self.runs])
 
     @text.setter
     def text(self, text):


### PR DESCRIPTION
During my tests with large docx files with @DrorRoth, we managed to increase Paragraph.text performance by 500%~ using this simple fix.
