### PR TITLE
Feature table enhancements

### DIFF
--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -163,6 +163,8 @@ from .table import (  # noqa
     CT_TrPr,
     CT_VMerge,
     CT_VerticalJc,
+    CT_Border,
+    CT_TcBorders
 )
 register_element_cls('w:bidiVisual', CT_OnOff)
 register_element_cls('w:gridCol',    CT_TblGridCol)
@@ -178,8 +180,20 @@ register_element_cls('w:tcW',        CT_TblWidth)
 register_element_cls('w:tr',         CT_Row)
 register_element_cls('w:trHeight',   CT_Height)
 register_element_cls('w:trPr',       CT_TrPr)
+register_element_cls('w:cantSplit',  CT_OnOff)
 register_element_cls('w:vAlign',     CT_VerticalJc)
 register_element_cls('w:vMerge',     CT_VMerge)
+register_element_cls('w:tcBorders',  CT_TcBorders)
+register_element_cls('w:top',        CT_Border)
+register_element_cls('w:start',      CT_Border)
+register_element_cls('w:left',       CT_Border)
+register_element_cls('w:bottom',     CT_Border)
+register_element_cls('w:end',        CT_Border)
+register_element_cls('w:right',      CT_Border)
+register_element_cls('w:insideH',    CT_Border)
+register_element_cls('w:insideV',    CT_Border)
+register_element_cls('w:tl2br',      CT_Border)
+register_element_cls('w:tr2bl',      CT_Border)
 
 from .text.font import (  # noqa
     CT_Color,

--- a/docx/oxml/__init__.py
+++ b/docx/oxml/__init__.py
@@ -164,7 +164,8 @@ from .table import (  # noqa
     CT_VMerge,
     CT_VerticalJc,
     CT_Border,
-    CT_TcBorders
+    CT_TcBorders,
+    CT_TblBorders
 )
 register_element_cls('w:bidiVisual', CT_OnOff)
 register_element_cls('w:gridCol',    CT_TblGridCol)
@@ -183,6 +184,7 @@ register_element_cls('w:trPr',       CT_TrPr)
 register_element_cls('w:cantSplit',  CT_OnOff)
 register_element_cls('w:vAlign',     CT_VerticalJc)
 register_element_cls('w:vMerge',     CT_VMerge)
+register_element_cls('w:tblBorders', CT_TblBorders)
 register_element_cls('w:tcBorders',  CT_TcBorders)
 register_element_cls('w:top',        CT_Border)
 register_element_cls('w:start',      CT_Border)

--- a/docx/oxml/simpletypes.py
+++ b/docx/oxml/simpletypes.py
@@ -407,3 +407,48 @@ class ST_VerticalAlignRun(XsdStringEnumeration):
     SUBSCRIPT = 'subscript'
 
     _members = (BASELINE, SUPERSCRIPT, SUBSCRIPT)
+
+class ST_Border(XsdString):
+    @classmethod
+    def validate(cls, value):
+        cls.validate_string(value)
+        valid_values = ('none', 'single', 'thick', 'double', 'dotted', 'dashed', 'dotDash', 'dotDotDash', 'triple',
+                        'thinThickSmallGap', 'thickThinSmallGap', 'thinThickThinSmallGap', 'thinThickMediumGap',
+                        'thickThinMediumGap', 'thinThickThinMediumGap', 'thinThickLargeGap', 'thickThinLargeGap',
+                        'thinThickThinLargeGap', 'wave', 'doubleWave', 'dashSmallGap', 'dashDotStroked', 'threeDEmboss',
+                        'threeDEngrave', 'outset', 'inset', 'apples', 'archedScallops', 'babyPacifier', 'babyRattle',
+                        'balloons3Colors', 'balloonsHotAir', 'basicBlackDashes', 'basicBlackDots', 'basicBlackSquares',
+                        'basicThinLines', 'basicWhiteDashes', 'basicWhiteDots', 'basicWhiteSquares', 'basicWideInline',
+                        'basicWideMidline', 'basicWideOutline', 'bats', 'birds', 'birdsFlight', 'cabins', 'cakeSlice',
+                        'candyCorn', 'celticKnotwork', 'certificateBanner', 'chainLink', 'champagneBottle', 'checkedBarBlack',
+                        'checkedBarColor', 'checkered', 'christmasTree', 'circlesLines', 'circlesRectangles', 'classicalWave',
+                        'clocks', 'compass', 'confetti', 'confettiGrays', 'confettiOutline', 'confettiStreamers',
+                        'confettiWhite', 'cornerTriangles', 'couponCutoutDashes', 'couponCutoutDots', 'crazyMaze',
+                        'creaturesButterfly', 'creaturesFish', 'creaturesInsects', 'creaturesLadyBug', 'crossStitch',
+                        'cup', 'decoArch', 'decoArchColor', 'decoBlocks', 'diamondsGray', 'doubleD', 'doubleDiamonds',
+                        'earth1', 'earth2', 'earth3', 'eclipsingSquares1', 'eclipsingSquares2', 'eggsBlack', 'fans',
+                        'film', 'firecrackers', 'flowersBlockPrint', 'flowersDaisies', 'flowersModern1', 'flowersModern2',
+                        'flowersPansy', 'flowersRedRose', 'flowersRoses', 'flowersTeacup', 'flowersTiny', 'gems',
+                        'gingerbreadMan', 'gradient', 'handmade1', 'handmade2', 'heartBalloon', 'heartGray', 'hearts',
+                        'heebieJeebies', 'holly', 'houseFunky', 'hypnotic', 'iceCreamCones', 'lightBulb', 'lightning1',
+                        'lightning2', 'mapPins', 'mapleLeaf', 'mapleMuffins', 'marquee', 'marqueeToothed', 'moons', 'mosaic',
+                        'musicNotes', 'northwest', 'ovals', 'packages', 'palmsBlack', 'palmsColor', 'paperClips', 'papyrus',
+                        'partyFavor', 'partyGlass', 'pencils', 'people', 'peopleWaving', 'peopleHats', 'poinsettias',
+                        'postageStamp', 'pumpkin1', 'pushPinNote2', 'pushPinNote1', 'pyramids', 'pyramidsAbove',
+                        'quadrants', 'rings', 'safari', 'sawtooth', 'sawtoothGray', 'scaredCat', 'seattle', 'shadowedSquares',
+                        'sharksTeeth', 'shorebirdTracks', 'skyrocket', 'snowflakeFancy', 'snowflakes', 'sombrero', 'southwest',
+                        'stars', 'starsTop', 'stars3d', 'starsBlack', 'starsShadowed', 'sun', 'swirligig', 'tornPaper',
+                        'tornPaperBlack', 'trees', 'triangleParty', 'triangles', 'triangle1', 'triangle2', 'triangleCircle1',
+                        'triangleCircle2', 'shapes1', 'shapes2', 'twistedLines1', 'twistedLines2', 'vine', 'waveline',
+                        'weavingAngles', 'weavingBraid', 'weavingRibbon', 'weavingStrips', 'whiteFlowers', 'woodwork',
+                        'xIllusions', 'zanyTriangles', 'zigZag', 'zigZagStitch', 'custom')
+        if value not in valid_values:
+            raise ValueError(
+                "must be one of %s, got '%s'" % (valid_values, value)
+            )
+
+class ST_PointMeasure(XsdUnsignedLong):
+    pass
+
+class ST_EighthPointMeasure(XsdUnsignedLong):
+    pass

--- a/docx/oxml/table.py
+++ b/docx/oxml/table.py
@@ -282,6 +282,7 @@ class CT_TblPr(BaseOxmlElement):
     tblStyle = ZeroOrOne('w:tblStyle', successors=_tag_seq[1:])
     bidiVisual = ZeroOrOne('w:bidiVisual', successors=_tag_seq[4:])
     jc = ZeroOrOne('w:jc', successors=_tag_seq[8:])
+    tblBorders = ZeroOrOne('w:tblBorders', successors=_tag_seq[11:])
     tblLayout = ZeroOrOne('w:tblLayout', successors=_tag_seq[13:])
     del _tag_seq
 
@@ -935,7 +936,47 @@ class CT_TcBorders(BaseOxmlElement):
     insideH = ZeroOrOne('w:insideH', successors=_tag_seq[7:])
     insideV = ZeroOrOne('w:insideV', successors=_tag_seq[8:])
     tl2br = ZeroOrOne('w:tl2br', successors=_tag_seq[9:])
-    tr2bl = ZeroOrOne('w:tr2bl', successors=_tag_seq[10:])
+    tr2bl = ZeroOrOne('w:tr2bl', successors=[])
+
+    @property
+    def as_dict(self):
+        borders = {}
+        for tag in self._tag_seq:
+            name = tag.split(':')[1]
+            brd = getattr(self, name, None)
+            if brd is None:
+                continue
+            borders[name] = brd
+        return borders
+
+    def add_border(self, name, line, sz=None, space=None, color=None):
+        if not 'w:%s' % name in self._tag_seq:
+            raise AttributeError('border %s can not be applied' % name)
+        get_or_add_method = getattr(self, 'get_or_add_%s' % name, None)
+        if get_or_add_method:
+            element = get_or_add_method()
+            element.val = line
+            if sz:
+                element.sz = sz
+            if space:
+                element.space = space
+            if color:
+                element.color = color
+            return element
+
+    def remove_border(self, name):
+        remove_method = getattr(self, '_remove_%s' % name, None)
+        if remove_method:
+            remove_method()
+
+class CT_TblBorders(BaseOxmlElement):
+    _tag_seq = ('w:top', 'w:start', 'w:bottom', 'w:end', 'w:insideH', 'w:insideV')
+    top = ZeroOrOne('w:top', successors=_tag_seq[1:])
+    start = ZeroOrOne('w:start', successors=_tag_seq[2:])
+    bottom = ZeroOrOne('w:bottom', successors=_tag_seq[3:])
+    end = ZeroOrOne('w:end', successors=_tag_seq[4:])
+    insideH = ZeroOrOne('w:insideH', successors=_tag_seq[5:])
+    insideV = ZeroOrOne('w:insideV', successors=[])
 
     @property
     def as_dict(self):

--- a/docx/table.py
+++ b/docx/table.py
@@ -298,6 +298,12 @@ class _Cell(BlockItemContainer):
     def width(self, value):
         self._tc.width = value
 
+    @lazyproperty
+    def borders(self):
+        """
+        |_Borders| instance containing the sequence of borders.
+        """
+        return _Borders(self._tc, self)
 
 class _Column(Parented):
     """
@@ -413,6 +419,30 @@ class _Row(Parented):
         self._tr.trHeight_val = value
 
     @property
+    def dont_split(self):
+        return self._get_bool_prop('cantSplit')
+
+    @dont_split.setter
+    def dont_split(self, value):
+        self._set_bool_prop('cantSplit', value)
+
+    def _get_bool_prop(self, name):
+        """
+        Return the value of boolean child of `w:trPr` having *name*.
+        """
+        trPr = self._element.trPr
+        if trPr is None:
+            return None
+        return trPr._get_bool_val(name)
+
+    def _set_bool_prop(self, name, value):
+        """
+        Assign *value* to the boolean child *name* of `w:trPr`.
+        """
+        trPr = self._element.get_or_add_trPr()
+        trPr._set_bool_val(name, value)
+
+    @property
     def height_rule(self):
         """
         Return the height rule of this cell as a member of the
@@ -467,3 +497,126 @@ class _Rows(Parented):
         Reference to the |Table| object this row collection belongs to.
         """
         return self._parent.table
+
+class _Border(Parented):
+    def __init__(self, name, cb, parent):
+        super(_Border, self).__init__(parent)
+        self._name = name
+        self._cb = self._element = cb
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        if value is None:
+            self._parent.remove_border(self.name)
+            return
+        self._parent.remove_border(self.name)
+        return self._parent.add_border(value, self.line, sz=self.size, space=self.space, color=self.color)
+
+    @property
+    def line(self):
+        return self._cb.val
+
+    @line.setter
+    def line(self, value):
+        if value is None:
+            self._cb._remove_val()
+            return
+        self._cb.val = value
+
+    @property
+    def size(self):
+        return self._cb.sz
+
+    @size.setter
+    def size(self, value):
+        if value is None:
+            self._cb._remove_sz()
+            return
+        self._cb.sz = value
+
+    @property
+    def space(self):
+        return self._cb.space
+
+    @space.setter
+    def space(self, value):
+        if value is None:
+            self._cb._remove_space()
+            return
+        self._cb.space = value
+
+    @property
+    def color(self):
+        return self._cb.color
+
+    @color.setter
+    def color(self, value):
+        if value is None:
+            self._cb._remove_color()
+            return
+        self._cb.color = value
+
+class _Borders(Parented):
+    """
+    Sequence of |_Border| objects.
+    Supports ``len()``, iteration, indexed access, and slicing.
+    """
+    def __init__(self, cell, parent):
+        super(_Borders, self).__init__(parent)
+        self._cell = cell
+
+    def __getitem__(self, idx):
+        return list(self)[idx]
+
+    def __iter__(self):
+        return (_Border(name, cb, self) for name, cb in self._borders.items())
+
+    def __len__(self):
+        return len(self._borders)
+
+    @property
+    def _tcBorders(self):
+        tcPr = self._cell.tcPr
+        if tcPr is None:
+            return None
+        tcBorders = tcPr.tcBorders
+        if tcBorders is None:
+            return None
+        return tcBorders
+
+    @property
+    def _borders(self):
+        tcBorders = self._tcBorders
+        if tcBorders is None:
+            return {}
+        return tcBorders.as_dict
+
+    @property
+    def table(self):
+        """
+        Reference to the |Table| object this row collection belongs to.
+        """
+        return self._parent.table
+
+    def add_border(self, name, line, sz=None, space=None, color=None):
+        tcPr = self._cell.get_or_add_tcPr()
+        if tcPr is None:
+            return None
+        tcBorders = tcPr.get_or_add_tcBorders()
+        if tcBorders is None:
+            return None
+        brd = tcBorders.add_border(name, line, sz=sz, space=space, color=color)
+        if brd is not None:
+            return _Border(name, brd, self)
+
+    def remove_border(self, border_name):
+        tcBorders = self._tcBorders
+        if tcBorders is None:
+            return None
+        remove_method = getattr(tcBorders, '_remove_%s' % border_name)
+        if remove_method:
+            remove_method()


### PR DESCRIPTION
Hi.
I've made some changes to Table and _Cell proxy classes as well as oxml classes templates.
This patch adds borders property to the Table and _Cell classes that could be used to get access to borders, add and remove borders of table and table cell.
In addition table _Row class has dont_split property that implements CT_TrPr w:cantSplit tag
I have not added any tests to the project, sorry for that.

Definitely my code might be optimized and refactored, but I have tried to keep along with current code style and base structure.

Code examples:
Table borders
```
from docx import Document
doc = Document()
tab = doc.add_table(rows=0, cols=2)
tab.autofit = True
for side in ('top', 'bottom', 'start', 'end'):
    tab.borders.add_border(side, 'single')
tab.borders.add_border('insideV', 'double')
# Change line style for the top border.
# One can change folowing properties of border instance:
# name = 'top' | 'bottom' | 'start' | 'end' |  'insideV' | 'insideH'
# causes removing existing border with old name and creating copy of the border with new name
# line: 'single' | 'double' and many other types of line documented in <xsd:simpleType name="ST_Shd"> 
# size: unsigned decimal ST_EighthPointMeasure
# space: unsigned decimal  ST_PointMeasure
# color:  'auto' and others corresponding to ST_HexColor
tab.borders[0].line = 'double'  
row = tab.add_row()
# Table row now have dont_split property to avoid of splitting paragraphs and runs of a row when page break accurs
row.dont_split = True
row.cells[0].text = 'Cell1'
doc.save('test_border.docx')
```
Table cell borders
```
from docx import Document
doc = Document()
tab = doc.add_table(rows=0, cols=2)
tab.autofit = True
row = tab.add_row()
cell = row.cells[0]
cell.text = 'Cell1'
for side in ('top', 'bottom', 'start', 'end'):
    cell.borders.add_border(side, 'single')
cell.borders.add_border('tl2br',  'double')
# One can change folowing properties of border instance:
# name = 'top' | 'start' | 'left' | 'bottom' | 'end' | 'right' | 'insideH' | 'insideV' | 'tl2br' | 'tr2bl'
cell.borders[0].line = 'double' 
doc.save('test_border.docx')
```
