### PR TITLE
Fix: media file path issue

### DIFF
--- a/docx/opc/pkgreader.py
+++ b/docx/opc/pkgreader.py
@@ -213,7 +213,7 @@ class _SerializedRelationship(object):
         self._rId = rel_elm.rId
         self._reltype = rel_elm.reltype
         self._target_mode = rel_elm.target_mode
-        self._target_ref = rel_elm.target_ref
+        self._target_ref = rel_elm.target_ref.replace('\\', '/') if '\\' in rel_elm.target_ref else rel_elm.target_ref 
 
     @property
     def is_external(self):


### PR DESCRIPTION
Not sure why there is certain time where the media file path is set as windows path format in word/_rels/document.xml.rels
This is a fix where when it detected windows path, change it back to unix.
![image](https://user-images.githubusercontent.com/56245538/232396601-dc7b42cb-c63e-4e87-b45d-808a92039f3b.png)
