### PR TITLE
Fix "descriptor '__dict__' for '_OxmlElementBase' objects doesn't apply to a 'CT_*' object" in Py3

### DIFF
--- a/docx/oxml/xmlchemy.py
+++ b/docx/oxml/xmlchemy.py
@@ -755,5 +755,5 @@ class _OxmlElementBase(etree.ElementBase):
 
 
 BaseOxmlElement = MetaOxmlElement(
-    'BaseOxmlElement', (etree.ElementBase,), dict(_OxmlElementBase.__dict__)
+    'BaseOxmlElement', (_OxmlElementBase,), dict(_OxmlElementBase.__dict__)
 )


### PR DESCRIPTION
The error is generated if the object is not a descendant of the descriptor's type

Happens for all classes derived from `BaseOxmlElement` when trying to `dir()` them.