### PR TITLE
Add `add_table_from_df` method to `Document` class

### DIFF
--- a/docx/blkcntnr.py
+++ b/docx/blkcntnr.py
@@ -50,6 +50,28 @@ class BlockItemContainer(Parented):
         self._element._insert_tbl(tbl)
         return Table(tbl, self)
 
+    def add_table_from_df(self, df, width, header):
+        """
+        Return a table with the data from the dataframe along with the column headings
+        """
+        idx_shift = 1 if header else 0
+        tbl = self.add_table(
+            rows=df.shape[0] + idx_shift, cols=df.shape[1], width=width
+        )
+
+        if header:
+            # Add the column headings
+            for j in range(df.shape[1]):
+                tbl.cell(0, j).text = df.columns[j]
+
+        # Add the body of the data frame
+        for i in range(df.shape[0]):
+            for j in range(df.shape[1]):
+                cell = df.iat[i, j]
+                tbl.cell(i + idx_shift, j).text = str(cell)
+
+        return tbl
+
     @property
     def paragraphs(self):
         """

--- a/docx/document.py
+++ b/docx/document.py
@@ -93,6 +93,24 @@ class Document(ElementProxy):
         table.style = style
         return table
 
+    def add_table_from_df(
+        self,
+        df,
+        style=None,
+        header=True,
+        auto_fit=True,
+    ):
+        """
+        Add a table having row and column counts of *rows* and *cols*
+        respectively and table style of *style*. *style* may be a paragraph
+        style object or a paragraph style name. If *style* is |None|, the
+        table inherits the default table style of the document.
+        """
+        table = self._body.add_table_from_df(df, self._block_width, header, auto_fit)
+        table.style = style
+        table.autofit = auto_fit
+        return table
+
     @property
     def core_properties(self):
         """


### PR DESCRIPTION
In our usage of this package, we find ourselves wanting to dump a pandas dataframe to a table.  We thought this would be generally useful and might be a good addition to the package.