### PR TITLE
Add build backend in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-docx"


### PR DESCRIPTION
Explicitly declare `setuptools.build_meta` as the build backend. 

I can’t easily reproduce the following problem with just `venv` or `build`, but for me, working on the [`python-docx` package in Fedora Linux](), this PR fixes the following:

```
+ /usr/bin/python3 -Bs /usr/lib/rpm/redhat/pyproject_buildrequires.py --generate-extr
as --python3_pkgversion 3 --wheeldir /builddir/build/BUILD/python-docx-1.0.1/pyprojec
t-wheeldir --output /builddir/build/BUILD/python-docx-1.0.1-1.fc40.x86_64-pyproject-b
uildrequires -t
Handling setuptools>=61.0.0 from build-system.requires
Requirement not satisfied: setuptools>=61.0.0
Traceback (most recent call last):
  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 555, in main
    generate_requires(
  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 450, in generate_requir
es
    backend = get_backend(requirements)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/rpm/redhat/pyproject_buildrequires.py", line 243, in get_backend
    raise FileNotFoundError('File "setup.py" not found for legacy project.')
FileNotFoundError: File "setup.py" not found for legacy project.
```

In any case, it matches the following reference: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html