### PR TITLE
Include requirements files in PyPI sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include HISTORY.rst LICENSE README.rst tox.ini
+include requirements*.txt
 graft src/docx/templates
 graft features
 graft tests


### PR DESCRIPTION
These are needed to run tests via `tox.ini`.