### PR TITLE
settings: get and set on trackRevisions

### DIFF
--- a/src/docx/oxml/__init__.py
+++ b/src/docx/oxml/__init__.py
@@ -76,6 +76,10 @@ register_element_cls("w:r", CT_R)
 register_element_cls("w:t", CT_Text)
 
 # ---------------------------------------------------------------------------
+# track revisions configurations
+register_element_cls("w:trackRevisions", CT_OnOff)
+
+# ---------------------------------------------------------------------------
 # header/footer-related mappings
 
 register_element_cls("w:evenAndOddHeaders", CT_OnOff)

--- a/src/docx/oxml/settings.py
+++ b/src/docx/oxml/settings.py
@@ -107,6 +107,7 @@ class CT_Settings(BaseOxmlElement):
         "w:listSeparator",
     )
     evenAndOddHeaders = ZeroOrOne("w:evenAndOddHeaders", successors=_tag_seq[48:])
+    trackRevisions = ZeroOrOne("w:trackRevisions", successors=_tag_seq[32:])
     del _tag_seq
 
     @property
@@ -117,9 +118,24 @@ class CT_Settings(BaseOxmlElement):
             return False
         return evenAndOddHeaders.val
 
+    @property
+    def trackRevisions_val(self):
+        """Value of `w:trackRevisions/@w:val` or |None| if not present."""
+        trackRevisions = self.trackRevisions
+        if trackRevisions is None:
+            return False
+        return trackRevisions.val
+
     @evenAndOddHeaders_val.setter
     def evenAndOddHeaders_val(self, value):
         if value in [None, False]:
             self._remove_evenAndOddHeaders()
         else:
             self.get_or_add_evenAndOddHeaders().val = value
+
+    @trackRevisions_val.setter
+    def trackRevisions_val(self, value):
+        if value in [None, False]:
+            self._remove_trackRevisions()
+        else:
+            self.get_or_add_trackRevisions().val = value

--- a/src/docx/settings.py
+++ b/src/docx/settings.py
@@ -17,6 +17,19 @@ class Settings(ElementProxy):
         """
         return self._element.evenAndOddHeaders_val
 
+    @property
+    def track_revisions(self):
+        """
+		True if this document has track revisions feature enabled.
+
+        Read/write.
+        """
+        return self._element.trackRevisions_val
+
     @odd_and_even_pages_header_footer.setter
     def odd_and_even_pages_header_footer(self, value):
         self._element.evenAndOddHeaders_val = value
+
+    @track_revisions.setter
+    def track_revisions(self, value):
+        self._element.trackRevisions_val = value

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,6 +28,26 @@ class DescribeSettings:
 
         assert settings_elm.xml == expected_xml
 
+    def it_knows_when_the_document_has_track_revisions(
+        self, track_revisions_get_fixture
+    ):
+        settings_elm, expected_value = track_revisions_get_fixture
+        settings = Settings(settings_elm)
+
+        track_revisions = settings.track_revisions
+
+        assert track_revisions is expected_value
+
+    def it_can_change_whether_the_document_has_track_revisions(
+        self, track_revisions_set_fixture
+    ):
+        settings_elm, value, expected_xml = track_revisions_set_fixture
+        settings = Settings(settings_elm)
+
+        settings.track_revisions = value
+
+        assert settings_elm.xml == expected_xml
+
     # fixtures -------------------------------------------------------
 
     @pytest.fixture(
@@ -57,6 +77,38 @@ class DescribeSettings:
         ]
     )
     def odd_and_even_set_fixture(self, request):
+        settings_cxml, value, expected_cxml = request.param
+        settings_elm = element(settings_cxml)
+        expected_xml = xml(expected_cxml)
+        return settings_elm, value, expected_xml
+
+    @pytest.fixture(
+        params=[
+            ("w:settings", False),
+            ("w:settings/w:trackRevisions", True),
+            ("w:settings/w:trackRevisions{w:val=0}", False),
+            ("w:settings/w:trackRevisions{w:val=1}", True),
+            ("w:settings/w:trackRevisions{w:val=true}", True),
+        ]
+    )
+    def track_revisions_get_fixture(self, request):
+        settings_cxml, expected_value = request.param
+        settings_elm = element(settings_cxml)
+        return settings_elm, expected_value
+
+    @pytest.fixture(
+        params=[
+            ("w:settings", True, "w:settings/w:trackRevisions"),
+            ("w:settings/w:trackRevisions", False, "w:settings"),
+            (
+                "w:settings/w:trackRevisions{w:val=1}",
+                True,
+                "w:settings/w:trackRevisions",
+            ),
+            ("w:settings/w:trackRevisions{w:val=off}", False, "w:settings"),
+        ]
+    )
+    def track_revisions_set_fixture(self, request):
         settings_cxml, value, expected_cxml = request.param
         settings_elm = element(settings_cxml)
         expected_xml = xml(expected_cxml)


### PR DESCRIPTION
**Feature:** Getter and setter for [trackRevisions](https://support.microsoft.com/en-us/office/track-changes-in-word-197ba630-0f5f-4a8e-9a77-3712475e806a) field in settings.xml.

I have a requirement to enable and disable trackRevisions flag on Docx files.
Here is an attempt to do that by enabling getter and setter on [trackRevisions](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.trackrevisions?view=openxml-2.8.1), which is similar to an already existing functionality [evenAndOddHeaders](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.evenandoddheaders?view=openxml-2.8.1). Used the [commit](https://github.com/python-openxml/python-docx/commit/a46dd645f94ad8b3c53878d3dae1a0510661317b) as reference.