### PR TITLE
Handle large docx files

### DIFF
--- a/src/docx/oxml/parser.py
+++ b/src/docx/oxml/parser.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 # -- configure XML parser --
 element_class_lookup = etree.ElementNamespaceClassLookup()
-oxml_parser = etree.XMLParser(remove_blank_text=True, resolve_entities=False)
+oxml_parser = etree.XMLParser(remove_blank_text=True, resolve_entities=False, huge_tree=True)
 oxml_parser.set_element_class_lookup(element_class_lookup)
 
 


### PR DESCRIPTION
fix issue were parser throws "AttValue length too long" error message for large docx files 