### PR TITLE
fixed a bug after using pyinstaller to pack programe in a Linux environment

### DIFF
--- a/src/docx/parts/hdrftr.py
+++ b/src/docx/parts/hdrftr.py
@@ -22,7 +22,7 @@ class FooterPart(StoryPart):
     def _default_footer_xml(cls):
         """Return bytes containing XML for a default footer part."""
         path = os.path.join(
-            os.path.split(__file__)[0], "..", "templates", "default-footer.xml"
+            os.path.dirname(os.path.split(__file__)[0]), "templates", "default-footer.xml"
         )
         with open(path, "rb") as f:
             xml_bytes = f.read()


### PR DESCRIPTION
![企业微信截图_17013373264927](https://github.com/python-openxml/python-docx/assets/31762160/db53f5af-1e94-4875-81ce-bd8b5a1ea073)

After packaging with PyInstaller, the absence of the 'parts' folder results in an error for the 'parts/../' path.