### PR TITLE
Refactor parse_xml function to handle external target references  (Issue  #1349)

### DIFF
--- a/src/docx/opc/oxml.py
+++ b/src/docx/opc/oxml.py
@@ -27,7 +27,8 @@ nsmap = {
 # ===========================================================================
 
 
-def parse_xml(text: str) -> etree._Element:  # pyright: ignore[reportPrivateUsage]
+# pyright: ignore[reportPrivateUsage]
+def parse_xml(text: str) -> etree._Element:
     """`etree.fromstring()` replacement that uses oxml parser."""
     return etree.fromstring(text, oxml_parser)
 
@@ -170,6 +171,8 @@ class CT_Relationship(BaseOxmlElement):
 
         Defaults to ``Internal``.
         """
+        if self.target_ref and self.target_ref.startswith("#"):
+            return RTM.EXTERNAL
         return self.get("TargetMode", RTM.INTERNAL)
 
 


### PR DESCRIPTION
The added code checks if self.target_ref exists and if it starts with a "#", which is a common way to denote external references. If both conditions are met, the method returns RTM.EXTERNAL, indicating that the target reference is external.

This change improves the robustness of our code by correctly handling and classifying external references. This will prevent potential errors or unexpected behavior when encountering such references.