### PR TITLE
Update Table Style Example in the Quickstart Guide

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -165,9 +165,9 @@ The same works for columns, although I've yet to see a use case for it.
 Word has a set of pre-formatted table styles you can pick from its table style
 gallery. You can apply one of those to the table like this::
 
-    table.style = 'LightShading-Accent1'
+    table.style = 'Light Shading Accent 1'
 
-The style name is formed by removing all the spaces from the table style name.
+The style name is formed by removing all the hyphens from the table style name.
 You can find the table style name by hovering your mouse over its thumbnail in
 Word's table style gallery.
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -167,7 +167,8 @@ gallery. You can apply one of those to the table like this::
 
     table.style = 'Light Shading Accent 1'
 
-The style name is formed by removing all the hyphens from the table style name.
+The style name is formed by removing all the hyphens from the table style name,
+so that *Light Shading - Accent 1* becomes *Light Shading Accent 1*.
 You can find the table style name by hovering your mouse over its thumbnail in
 Word's table style gallery.
 


### PR DESCRIPTION
This PR updates the table style example offered in the quickstart guide.

Currently, the quickstart guide reports an example to style tables which probably refers to an older version of python-docx. Using this example in a project running the latest version of the library (1.1.0) leads to a deprecation message "UserWarning: style lookup by style_id is deprecated. Use style name as key instead."

The API documentation reports [the up-to-date convention](https://python-docx.readthedocs.io/en/latest/api/table.html#docx.table.Table.style) to style tables (TL;NR the table style name allows spaces but not hyphens). This PR updates the example and its description to match the new convention.