### PR TITLE
Update install.rst

### DIFF
--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -28,7 +28,7 @@ and running ``setup.py``::
 
 |docx| depends on the ``lxml`` package. Both ``pip`` and ``easy_install``
 will take care of satisfying those dependencies for you, but if you use this
-last method you will need to install those yourself.
+last method you will need to install that yourself.
 
 
 Dependencies


### PR DESCRIPTION
In this paragraph, we are talking about the singular package ```lxml```. "Those" is used when talking in plural. Hence why I changed it to "that".