### PR TITLE
Odd table shapes issue

### DIFF
--- a/src/docx/table.py
+++ b/src/docx/table.py
@@ -174,7 +174,8 @@ class Table(StoryChild):
                 if tc.vMerge == ST_Merge.CONTINUE:
                     cells.append(cells[-col_count])
                 elif grid_span_idx > 0:
-                    cells.append(cells[-1])
+                    if len(cells) > 0:
+                        cells.append(cells[-1])
                 else:
                     cells.append(_Cell(tc, self))
         return cells


### PR DESCRIPTION
I am pre-processing a large number of `.docx` documents with really oddly shaped tables containing text that has to be extracted verbatim.

As useful `python-docx` has been in this task, a subset of those documents revealed a tiny little bug in [this line](https://github.com/aanastasiou/python-docx/blob/fix_odd_table_shape_bug/src/docx/table.py#L177).

This PR fixes cases of odd table shapes were the strategy of populating a cell with the value of the previous cell (e.g. in the case of row/cell merges) fails, because there simply has not been a 'previous cell' yet.

Please note, I would be glad to contribute a test case as well but this might take a bit more time, tracking down the exact table (within the XML) that causes the bug and creating an "equivalent" test case.

Hope this helps.