### PR TITLE
fix zipfile.py 'UserWarning: Duplicate name: docProps/core.xml'

### DIFF
--- a/src/docx/opc/constants.py
+++ b/src/docx/opc/constants.py
@@ -313,6 +313,10 @@ class RELATIONSHIP_TYPE:
         "http://schemas.openxmlformats.org/package/2006/relationships/metada"
         "ta/core-properties"
     )
+    CORE_PROPERTIES_OFFICEDOCUMENT = (
+        "http://schemas.openxmlformats.org/officedocument/2006/relationships"
+        "/metadata/core-properties"
+    )
     CUSTOM_PROPERTIES = (
         "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
         "/custom-properties"

--- a/src/docx/opc/package.py
+++ b/src/docx/opc/package.py
@@ -175,9 +175,12 @@ class OpcPackage:
         try:
             return cast(CorePropertiesPart, self.part_related_by(RT.CORE_PROPERTIES))
         except KeyError:
-            core_properties_part = CorePropertiesPart.default(self)
-            self.relate_to(core_properties_part, RT.CORE_PROPERTIES)
-            return core_properties_part
+            try:
+                return cast(CorePropertiesPart, self.part_related_by(RT.CORE_PROPERTIES_OFFICEDOCUMENT))
+            except KeyError:
+                core_properties_part = CorePropertiesPart.default(self)
+                self.relate_to(core_properties_part, RT.CORE_PROPERTIES)
+                return core_properties_part
 
 
 class Unmarshaller:


### PR DESCRIPTION
Some documents in _rels/.rels, for the relation the targets "docProps/core.xml", have the relationship type
`http://schemas.openxmlformats.org/officedocument/2006/relationships/metadata/core-properties` 
instead of
`http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties`

In these cases, python-docx doesn't see that the core-properties are already set, it creates new ones and append a duplicate docProps/core.xml file in the zip