### PR TITLE
add element as a public property not _element which is private

### DIFF
--- a/src/docx/text/paragraph.py
+++ b/src/docx/text/paragraph.py
@@ -171,3 +171,7 @@ class Paragraph(StoryChild):
         """Return a newly created paragraph, inserted directly before this paragraph."""
         p = self._p.add_p_before()
         return Paragraph(p, self._parent)
+
+    @property
+    def element(self):
+        return self._element


### PR DESCRIPTION
a small addition to help with IDEs that highlight accessing a paragraph with _element as an inconsistency