### PR TITLE
Fix Ascii IFD reading as TIFF6.0 spec

### DIFF
--- a/src/docx/image/tiff.py
+++ b/src/docx/image/tiff.py
@@ -236,6 +236,8 @@ class _AsciiIfdEntry(_IfdEntry):
         The length of the string, including a terminating '\x00' (NUL) character, is in
         `value_count`.
         """
+        if value_count <= 4:
+            return stream_rdr.read_str(value_count - 1, offset + 8)
         return stream_rdr.read_str(value_count - 1, value_offset)
 
 


### PR DESCRIPTION
This PR fixes #187 

The [TIFF6](https://download.osgeo.org/libtiff/doc/TIFF6.pdf) specification writes:

> 
> Value/Offset
> To save time and space the Value Offset contains the Value instead of pointing to
> the Value if and only if the Value fits into 4 bytes. If the Value is shorter than 4
> bytes, it is left-justified within the 4-byte Value Offset, i.e., stored in the lower-
> numbered bytes. Whether the Value fits within 4 bytes is determined by the Type
> and Count of the field.
> 


python-docx by default uses the Value/Offset field as a offset for ASCII IFD, but sometime the Value/Offset field could contain directly the Value (if it contains a string with 4 or less characters including the final NULL byte/string terminator)

This is the case for the 2 pictures linked in issue #187 (the `Software` ASCII field contains `8.3`)
<img width="251" alt="image" src="https://github.com/user-attachments/assets/a4e3393e-9da3-4ec9-9db3-9ddaf2029c4a">
