### PR TITLE
resolve issue #1475 Non-integer font sizes 

### DIFF
--- a/src/docx/oxml/simpletypes.py
+++ b/src/docx/oxml/simpletypes.py
@@ -262,7 +262,7 @@ class ST_HpsMeasure(XsdUnsignedLong):
     def convert_from_xml(cls, str_value: str) -> Length:
         if "m" in str_value or "n" in str_value or "p" in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Pt(int(str_value) / 2.0)
+        return Pt(float(str_value) / 2.0)
 
     @classmethod
     def convert_to_xml(cls, value: int | Length) -> str:


### PR DESCRIPTION
In this change I have just converted data returned by the function convert_from_xml found in src\docx\oxml\simpletypes.py from int to float this would help solve the issue raised in #1475.
![image](https://github.com/user-attachments/assets/61f46480-1f0b-47c5-a404-bcf0e918ad89)
