### PR TITLE
Skip null and internal bookmarks links when loading document

### DIFF
--- a/src/docx/opc/pkgreader.py
+++ b/src/docx/opc/pkgreader.py
@@ -250,5 +250,13 @@ class _SerializedRelationships:
         if rels_item_xml is not None:
             rels_elm = parse_xml(rels_item_xml)
             for rel_elm in rels_elm.Relationship_lst:
+                # Null target
+                if rel_elm.target_ref in ("../NULL", "NULL"):
+                    continue
+                # Internal bookmarks
+                if rel_elm.target_ref.startswith("#_") or rel_elm.target_ref.startswith(
+                    "#"
+                ):
+                    continue
                 srels._srels.append(_SerializedRelationship(baseURI, rel_elm))
         return srels


### PR DESCRIPTION
This PR aims at fixing a recurring issue when loading docx files that have elements pointing to an internal bookmark or a target that is NULL.

Fixed issues with this PR:
- https://github.com/python-openxml/python-docx/issues/902
- https://github.com/python-openxml/python-docx/issues/1105
- https://github.com/python-openxml/python-docx/issues/1351

Docling issue as well (and other projects using docx)
- https://github.com/docling-project/docling/issues/1645


Still, there is also an issue with customXML missing elements [here](https://github.com/docling-project/docling/issues/1645#issuecomment-2938558454) : `KeyError: "There is no item named 'customXML/item5.xml' in the archive"` that is not taken care of, I'll don't know if adding another edge case is a good idea, or if you have a better approach in mind.