### PR TITLE
Refactor parse_xml function to handle external target references (Issue #1349) (old PR #1350)

### DIFF
--- a/src/docx/opc/oxml.py
+++ b/src/docx/opc/oxml.py
@@ -175,6 +175,8 @@ class CT_Relationship(BaseOxmlElement):
 
         Defaults to ``Internal``.
         """
+        if self.target_ref and self.target_ref.startswith("#"):
+            return RTM.EXTERNAL
         return self.get("TargetMode", RTM.INTERNAL)
 
 


### PR DESCRIPTION
I start from this issue/PR:
#1350 
Trying to push again for this change to be merged/integrated, as people still face the issue/bug if this won't be merged.
In many projects I had to use the custom commits on forks to make it work, the discussion/conversation in PR 1350 shows that the issue is felt by a significant number of users and it would be nice to have this very little change finally merged @scanny 

THE MODIFICATION IS:

> The added code checks if self.target_ref exists and if it starts with a "#", which is a common way to denote external references. If both conditions are met, the method returns RTM.EXTERNAL, indicating that the target reference is external.
> 
> This change improves the robustness of our code by correctly handling and classifying external references. This will prevent potential errors or unexpected behavior when encountering such references.

Please merge this change now that the modification is properly aligned with latest code version and has no conflicts.
