### PR TITLE
Add full alt-text (title and description) support for pictures and inline shapes

### DIFF
--- a/src/docx/document.py
+++ b/src/docx/document.py
@@ -123,6 +123,8 @@ class Document(ElementProxy):
         image_path_or_stream: str | IO[bytes],
         width: int | Length | None = None,
         height: int | Length | None = None,
+        title: str | None = None,
+        descr: str | None = None,
     ):
         """Return new picture shape added in its own paragraph at end of the document.
 
@@ -133,9 +135,12 @@ class Document(ElementProxy):
         aspect ratio of the image. The native size of the picture is calculated using
         the dots-per-inch (dpi) value specified in the image file, defaulting to 72 dpi
         if no value is specified, as is often the case.
+
+        `title` sets the image's alternative-text title.
+        `descr` sets the alternative-text description shown in Word's Alt Text pane.
         """
         run = self.add_paragraph().add_run()
-        return run.add_picture(image_path_or_stream, width, height)
+        return run.add_picture(image_path_or_stream, width, height, title, descr)
 
     def add_section(self, start_type: WD_SECTION = WD_SECTION.NEW_PAGE):
         """Return a |Section| object newly added at the end of the document.

--- a/src/docx/oxml/shape.py
+++ b/src/docx/oxml/shape.py
@@ -77,7 +77,7 @@ class CT_Inline(BaseOxmlElement):
     )
 
     @classmethod
-    def new(cls, cx: Length, cy: Length, shape_id: int, pic: CT_Picture) -> CT_Inline:
+    def new(cls, cx: Length, cy: Length, shape_id: int, pic: CT_Picture, title=None, descr=None) -> CT_Inline:
         """Return a new ``<wp:inline>`` element populated with the values passed as
         parameters."""
         inline = cast(CT_Inline, parse_xml(cls._inline_xml()))
@@ -85,13 +85,15 @@ class CT_Inline(BaseOxmlElement):
         inline.extent.cy = cy
         inline.docPr.id = shape_id
         inline.docPr.name = "Picture %d" % shape_id
+        if title: inline.docPr.title = title
+        if descr: inline.docPr.descr = descr
         inline.graphic.graphicData.uri = "http://schemas.openxmlformats.org/drawingml/2006/picture"
         inline.graphic.graphicData._insert_pic(pic)
         return inline
 
     @classmethod
     def new_pic_inline(
-        cls, shape_id: int, rId: str, filename: str, cx: Length, cy: Length
+        cls, shape_id: int, rId: str, filename: str, cx: Length, cy: Length, title=None, descr=None
     ) -> CT_Inline:
         """Create `wp:inline` element containing a `pic:pic` element.
 
@@ -99,7 +101,7 @@ class CT_Inline(BaseOxmlElement):
         """
         pic_id = 0  # Word doesn't seem to use this, but does not omit it
         pic = CT_Picture.new(pic_id, filename, rId, cx, cy)
-        inline = cls.new(cx, cy, shape_id, pic)
+        inline = cls.new(cx, cy, shape_id, pic, title=title, descr=descr)
         return inline
 
     @classmethod
@@ -126,6 +128,8 @@ class CT_NonVisualDrawingProps(BaseOxmlElement):
 
     id = RequiredAttribute("id", ST_DrawingElementId)
     name = RequiredAttribute("name", XsdString)
+    title = OptionalAttribute('title', XsdString)
+    descr = OptionalAttribute('descr', XsdString)
 
 
 class CT_NonVisualPictureProperties(BaseOxmlElement):

--- a/src/docx/parts/story.py
+++ b/src/docx/parts/story.py
@@ -62,6 +62,8 @@ class StoryPart(XmlPart):
         image_descriptor: str | IO[bytes],
         width: int | Length | None = None,
         height: int | Length | None = None,
+        title: str | None = None,
+        descr: str | None = None,
     ) -> CT_Inline:
         """Return a newly-created `w:inline` element.
 
@@ -71,7 +73,7 @@ class StoryPart(XmlPart):
         rId, image = self.get_or_add_image(image_descriptor)
         cx, cy = image.scaled_dimensions(width, height)
         shape_id, filename = self.next_id, image.filename
-        return CT_Inline.new_pic_inline(shape_id, rId, filename, cx, cy)
+        return CT_Inline.new_pic_inline(shape_id, rId, filename, cx, cy, title, descr)
 
     @property
     def next_id(self) -> int:

--- a/src/docx/shape.py
+++ b/src/docx/shape.py
@@ -101,3 +101,42 @@ class InlineShape:
     def width(self, cx: Length):
         self._inline.extent.cx = cx
         self._inline.graphic.graphicData.pic.spPr.cx = cx
+
+    @property
+    def alt_text(self) -> str | None:
+        """Read/write alternative-text description for this inline shape.
+
+        This corresponds to the 'Description' field in Word's Alt Text pane and is
+        stored on the ``wp:docPr`` ``descr`` attribute.
+        """
+        docPr = self._inline.docPr
+        if docPr is None:
+            return None
+        return docPr.descr
+
+    @alt_text.setter
+    def alt_text(self, value: str | None) -> None:
+        docPr = self._inline.docPr
+        if docPr is None:
+            return
+        # Setting to empty/None clears the attribute.
+        docPr.descr = value if value else None
+
+    @property
+    def alt_title(self) -> str | None:
+        """Read/write alternative-text title for this inline shape.
+
+        This corresponds to the 'Title' field in Word's Alt Text pane and is
+        stored on the ``wp:docPr`` ``title`` attribute.
+        """
+        docPr = self._inline.docPr
+        if docPr is None:
+            return None
+        return docPr.title
+
+    @alt_title.setter
+    def alt_title(self, value: str | None) -> None:
+        docPr = self._inline.docPr
+        if docPr is None:
+            return
+        docPr.title = value if value else None

--- a/src/docx/text/run.py
+++ b/src/docx/text/run.py
@@ -61,6 +61,8 @@ class Run(StoryChild):
         image_path_or_stream: str | IO[bytes],
         width: int | Length | None = None,
         height: int | Length | None = None,
+        title: str | None = None,
+        descr: str | None = None,
     ) -> InlineShape:
         """Return |InlineShape| containing image identified by `image_path_or_stream`.
 
@@ -75,8 +77,11 @@ class Run(StoryChild):
         ratio of the image. The native size of the picture is calculated using the dots-
         per-inch (dpi) value specified in the image file, defaulting to 72 dpi if no
         value is specified, as is often the case.
+
+        `title` sets the image's alternative-text title. `descr` sets the alternative-text
+        description shown in Word's Alt Text pane.
         """
-        inline = self.part.new_pic_inline(image_path_or_stream, width, height)
+        inline = self.part.new_pic_inline(image_path_or_stream, width, height, title, descr)
         self._r.add_drawing(inline)
         return InlineShape(inline)
 


### PR DESCRIPTION
_Builds on #227 and #317._

### Summary
This PR introduces first-class support for Word Alt Text in `python-docx`. Users can now set and read both the *Alt Text Title* and *Alt Text Description* (as shown in Word’s Accessibility pane) directly through the API when inserting or editing pictures.

### Motive
Previously, `python-docx` did not expose a clean API for working with image alternative text. Users had to manually manipulate XML to set or retrieve `<wp:docPr>` attributes (`title`, `descr`). This enhancement improves accessibility workflows and enables automated tools (e.g., alt-text generators) to embed compliant descriptions directly into Word documents.

### Implementation
* **`CT_NonVisualDrawingProps`** (`oxml/shape.py`): Added optional attributes `title` and `descr`.
* **`CT_Inline.new()` / `new_pic_inline()`**: Accept and apply `title` / `descr` to `<wp:docPr>`.
* **`StoryPart.new_pic_inline()`**: Added `title` and `descr` parameters and forwarded them to `CT_Inline.new_pic_inline()`.
* **`Run.add_picture()`** and **`Document.add_picture()`**: Updated to accept and pass through `title` and `descr` for inline pictures.
* **`InlineShape`** (`shape.py`): Added new `alt_text` and `alt_title` properties for convenient read/write access to `docPr.descr` and `docPr.title`.

### Usage Examples

```python
from docx import Document
from docx.shared import Inches

doc = Document()

# Insert an image with alt text
doc.add_picture(
    "chart.png",
    width=Inches(5),
    descr="Line chart showing sales growth from 2020 to 2024.",
    title="Sales Growth Chart"
)

# Access or modify alt text of an existing shape
shape = doc.inline_shapes[0]
print(shape.alt_text)      # "Line chart showing sales growth from 2020 to 2024."
shape.alt_text = "Updated alt text description."
shape.alt_title = "Updated title."
doc.save("report_with_alt_text.docx")
```

### Additional Notes
* Verified functionality using a test script that inserted an image, saved, reloaded, and confirmed `alt_title` and alt_text persisted correctly.
* No breaking API changes; `title` and `descr` are optional.
* Works across all story parts (document, headers, footers).
* Backwards compatible with existing documents.
* Enables accessibility tooling, automated captioning, and alt-text validation in Word documents.